### PR TITLE
Add repository health files and settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sh]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,37 @@
+name: Bug Report
+description: Report a broken or misbehaving skill
+labels: ["bug"]
+body:
+  - type: input
+    id: skill
+    attributes:
+      label: Skill name
+      description: Which skill is affected?
+      placeholder: e.g., enhance
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      value: |
+        1. Run `/<skill-name>`
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: Which Claude model were you using?
+      placeholder: e.g., claude-opus-4-6
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/skill_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_request.yml
@@ -1,0 +1,37 @@
+name: Skill Request
+description: Propose a new skill for the collection
+labels: ["enhancement"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Proposed skill name
+      description: A short, lowercase name (e.g., `review-pr`, `explain`)
+      placeholder: e.g., my-skill
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What should this skill do?
+      description: Describe the workflow — what does it take as input, what does it produce?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why is this useful?
+      description: What problem does it solve? How often would you use it?
+    validations:
+      required: true
+  - type: dropdown
+    id: model
+    attributes:
+      label: Recommended model
+      description: Which model tier does this skill need?
+      options:
+        - Haiku (fast, simple tasks)
+        - Sonnet (balanced)
+        - Opus (complex, multi-step reasoning)
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- What does this PR do? If it adds a new skill, describe what the skill does. -->
+
+## Checklist
+
+- [ ] `./lint.sh` passes with no errors
+- [ ] Skill `name` field matches directory name
+- [ ] `README.md` has all required sections (What It Does, Requirements, Usage, Configuration)
+- [ ] Skills table in root `README.md` is updated (if adding/removing a skill)
+- [ ] `CHANGELOG.md` is updated

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint Skills
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run skill linter
+        run: chmod +x lint.sh && ./lint.sh

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 .idea/
 .claude/
 *.bak
+.env*
+*.log
+node_modules/
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- CONTRIBUTING.md with guidelines for creating and submitting skills
+- SECURITY.md with trust model and vulnerability reporting process
+- GitHub Actions CI workflow to run the skill linter on push and PR
+- Issue templates for bug reports and skill requests
+- Pull request template with submission checklist
+- CHANGELOG.md (this file)
+- .editorconfig for consistent formatting
+
+### Changed
+- README.md: added badges, usage example, contributing section, and support info
+- .gitignore: added defensive entries for .env, logs, node_modules, and __pycache__
+
+## [1.0.0] - 2025-03-25
+
+### Added
+- `github-audit` skill: audits GitHub repositories against best practices
+- Skill Quality Kit: CLAUDE.md specification, starter templates, and lint.sh validator
+- `enhance` skill: deep multi-phase project analysis with install script

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+Thanks for your interest in contributing to Claude Code Custom Skills! This guide will help you get started.
+
+## Proposing a New Skill
+
+Before writing code, [open a Skill Request issue](https://github.com/thijsvos/Claude_Skills/issues/new?template=skill_request.yml) to discuss the idea. This helps avoid duplicate work and ensures the skill fits the collection.
+
+## Creating a Skill
+
+1. **Copy the templates** to a new directory under `skills/`:
+   ```bash
+   cp -r templates/ skills/my-skill/
+   ```
+
+2. **Edit `SKILL.md`** — fill in the frontmatter and write the skill prompt:
+   ```yaml
+   ---
+   name: my-skill
+   description: What the skill does
+   allowed-tools: Read, Grep, Glob
+   model: opus          # optional: opus, sonnet, haiku
+   effort: max          # optional: min, low, medium, high, max
+   ---
+
+   Skill prompt content here...
+   ```
+
+3. **Edit `README.md`** — document the skill with these required sections:
+   - **Title** and one-line description
+   - **What It Does** — describe the workflow
+   - **Requirements** — model access, dependencies
+   - **Usage** — how to invoke (e.g., `/my-skill`)
+   - **Configuration** — table of frontmatter settings
+   - **Safety** (if applicable) — what the skill can and cannot modify
+
+4. **Validate** your skill:
+   ```bash
+   ./lint.sh my-skill
+   ```
+
+5. **Update the skills table** in the root `README.md`.
+
+6. **Update `CHANGELOG.md`** with your addition under `## [Unreleased]`.
+
+See [CLAUDE.md](CLAUDE.md) for the full specification and quality standards.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a feature branch
+2. Make your changes following the steps above
+3. Ensure `./lint.sh` passes with no errors
+4. Open a PR — the [PR template](.github/PULL_REQUEST_TEMPLATE.md) includes a checklist
+
+## Quality Standards
+
+- **Minimal permissions**: only request tools the skill actually needs in `allowed-tools`
+- **Clear description**: the `description` field should be understandable without reading the full prompt
+- **Safety-conscious**: skills that launch subagents should use read-only agent types during analysis phases
+- **Self-contained**: each skill directory should contain everything needed; avoid cross-skill dependencies
+
+## Reporting Bugs
+
+Found a broken skill? [Open a Bug Report](https://github.com/thijsvos/Claude_Skills/issues/new?template=bug_report.yml).
+
+## Questions?
+
+Open a [discussion](https://github.com/thijsvos/Claude_Skills/issues) or file an issue — we're happy to help.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Claude Code Custom Skills
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Lint Skills](https://github.com/thijsvos/Claude_Skills/actions/workflows/lint.yml/badge.svg)](https://github.com/thijsvos/Claude_Skills/actions/workflows/lint.yml)
+
 A curated collection of custom skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that extend its capabilities with specialized, reusable workflows.
+
+[Claude Code skills](https://docs.anthropic.com/en/docs/claude-code) are prompt-based extensions that add new slash commands to your Claude Code CLI. Install a skill, then invoke it with `/<skill-name>` — no plugins or config needed.
 
 ## Available Skills
 
@@ -23,6 +28,15 @@ cd Claude_Skills
 
 ```bash
 ./install.sh enhance
+```
+
+### Use a Skill
+
+Once installed, invoke any skill inside Claude Code:
+
+```
+> /enhance
+> /github-audit
 ```
 
 ## How It Works
@@ -92,6 +106,14 @@ The linter validates:
 The `templates/` directory contains starter files for new skills:
 - `templates/SKILL.md` — Skill definition with all frontmatter fields documented
 - `templates/README.md` — Documentation template with all required sections
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on creating and submitting skills.
+
+- **Propose a skill**: [open a Skill Request](https://github.com/thijsvos/Claude_Skills/issues/new?template=skill_request.yml)
+- **Report a bug**: [open a Bug Report](https://github.com/thijsvos/Claude_Skills/issues/new?template=bug_report.yml)
+- **Security issues**: see [SECURITY.md](SECURITY.md)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Understanding the Trust Model
+
+Claude Code skills are prompt-based extensions that can request access to powerful tools — including shell commands, file reads/writes, and web access. A malicious or poorly written skill could:
+
+- Read or modify files on your system
+- Execute arbitrary shell commands
+- Exfiltrate data via network requests
+
+**Users should review any skill's `SKILL.md` before installing it**, paying particular attention to the `allowed-tools` field and the prompt content.
+
+## Reporting a Vulnerability
+
+If you discover a security issue in a skill (e.g., a skill that exfiltrates data, executes unintended commands, or requests excessive permissions), please report it responsibly:
+
+1. **Do not open a public issue.** Security vulnerabilities should be reported privately.
+2. **Use [GitHub Security Advisories](https://github.com/thijsvos/Claude_Skills/security/advisories/new)** to report the issue privately.
+3. Alternatively, email the maintainer directly.
+
+You should receive an acknowledgment within 48 hours and a resolution timeline within 7 days.
+
+## What Counts as a Security Issue
+
+- A skill requesting more permissions than it needs (`allowed-tools` is too broad)
+- A skill prompt that could cause data exfiltration or destructive actions
+- A skill that bypasses Claude Code's safety boundaries
+- The `install.sh` script overwriting files without proper backup/warning
+
+## Scope
+
+This policy covers the skills, install script, and linter in this repository. It does not cover Claude Code itself — for Claude Code security issues, refer to [Anthropic's security page](https://www.anthropic.com/security).


### PR DESCRIPTION
## Summary

Implements all recommendations from the GitHub repository audit to bring the project up to open-source best practices:

- **CI/CD**: GitHub Actions workflow to lint skills on push/PR
- **README**: Badges (license, CI status), usage example, contributing section, support info
- **Community health**: CONTRIBUTING.md, SECURITY.md, issue templates (bug report, skill request), PR template
- **Documentation**: CHANGELOG.md (Keep a Changelog format), .editorconfig
- **Git hygiene**: Hardened .gitignore with defensive entries
- **Repo settings**: Description and topics set via `gh repo edit`

Closes #1, #2, #3, #4, #5, #6, #7, #9, #10.

> **Note:** #8 (release and tagging strategy) will be handled separately after this PR is merged — the first release tag (`v1.0.0`) should be created on `main`.

## Test plan

- [x] `./lint.sh` passes with no errors
- [x] CI workflow triggers on this PR
- [x] Issue templates render correctly on GitHub
- [x] PR template loads for new PRs
- [x] Badges resolve after CI runs