### PR TITLE
Add release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        run: |
+          # Extract the section for this version from CHANGELOG.md
+          # Matches from "## [X.Y.Z]" until the next "## [" or end of file
+          version="${{ steps.version.outputs.version }}"
+          notes=$(awk -v ver="$version" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Write to output using delimiter syntax
+          {
+            echo "notes<<RELEASE_NOTES_EOF"
+            echo "$notes"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "${{ steps.notes.outputs.notes }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 - CODE_OF_CONDUCT.md (Contributor Covenant v2.1)
 - Dependabot configuration for GitHub Actions updates
+- Release automation workflow: auto-creates GitHub Releases from CHANGELOG when a version tag is pushed
 
 ## [0.0.1] - 2026-03-25
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-creates GitHub Releases when a version tag is pushed.

- Triggers on `v*` tags (e.g., `v0.1.0`)
- Extracts release notes from the matching `CHANGELOG.md` section
- Creates a GitHub Release with the tag name and extracted notes

No more manual `gh release create` — just tag and push.

## Test plan

- [ ] Push a test tag and verify the workflow creates a release with correct notes