### PR TITLE
Set effort: max for code-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A curated collection of custom skills for [Claude Code](https://docs.anthropic.c
 |-------|-------------|-------|--------|
 | [enhance](skills/enhance/) | Deep multi-phase project analysis that identifies and recommends the single most impactful addition to implement | Opus | Max |
 | [github-audit](skills/github-audit/) | Audits a GitHub repository against best practices and provides prioritized recommendations | Opus | Max |
-| [code-review](skills/code-review/) | Structured code review with prioritized findings and fix offers | Opus | — |
+| [code-review](skills/code-review/) | Structured code review with prioritized findings and fix offers | Opus | Max |
 
 ## Quick Start
 

--- a/skills/code-review/README.md
+++ b/skills/code-review/README.md
@@ -31,6 +31,7 @@ Analyzes code changes across multiple quality dimensions using parallel AI agent
 | Setting | Value |
 |---------|-------|
 | Model | `opus` |
+| Effort | `max` |
 | Takes argument | Yes |
 | Allowed tools | Read, Grep, Glob, Bash, Agent |
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -3,6 +3,7 @@ name: code-review
 description: Structured code review across correctness, security, performance, and conventions with prioritized findings and fix offers.
 allowed-tools: Read, Grep, Glob, Bash, Agent
 model: opus
+effort: max
 takes-arg: true
 ---
 


### PR DESCRIPTION
## Summary

- Add `effort: max` to `code-review` SKILL.md frontmatter
- Add Effort row to skill README Configuration table
- Update root README skills table from `—` to `Max`

Closes #24

## Test plan

- [x] `./lint.sh code-review` passes