### PR TITLE
Harden CI workflows for public release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run skill linter
         run: chmod +x lint.sh && ./lint.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,16 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` to full commit SHA (`de0fac2e`) instead of mutable `@v6` tag
- Add `concurrency` groups with `cancel-in-progress: true` to both workflows
- Add `timeout-minutes: 5` to all jobs

Closes #28

## Test plan

- [x] Workflow YAML is valid
- [ ] Lint workflow runs successfully after merge
- [ ] Release workflow runs successfully on next tag push