### PR TITLE
Add dep-check skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.0.4] - 2026-03-29
+
 ### Added
 - `dep-check` skill: scans all dependency declarations across ecosystems for updates and vulnerabilities, produces a prioritized update plan with testing recommendations
 
@@ -43,7 +45,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - README.md with badges, usage example, contributing section, and support info
 - .gitignore with defensive entries for .env, logs, node_modules, and __pycache__
 
-[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.3...HEAD
+[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.4...HEAD
+[0.0.4]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/thijsvos/Claude_Skills/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- `dep-check` skill: scans all dependency declarations across ecosystems for updates and vulnerabilities, produces a prioritized update plan with testing recommendations
+
 ## [0.0.3] - 2026-03-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A curated collection of custom skills for [Claude Code](https://docs.anthropic.c
 | [github-audit](skills/github-audit/) | Audits a GitHub repository against best practices and provides prioritized recommendations | Opus | Max |
 | [code-review](skills/code-review/) | Structured code review with prioritized findings and fix offers | Opus | Max |
 | [test-gen](skills/test-gen/) | Comprehensive test generation with deep code analysis, convention detection, and edge case coverage | Opus | Max |
+| [dep-check](skills/dep-check/) | Scans dependencies across ecosystems for updates and vulnerabilities, produces a prioritized update plan | Opus | Max |
 
 ## Quick Start
 
@@ -41,6 +42,7 @@ Once installed, invoke any skill inside Claude Code:
 > /github-audit
 > /code-review src/auth/
 > /test-gen src/utils.ts
+> /dep-check
 ```
 
 ## How It Works

--- a/skills/dep-check/README.md
+++ b/skills/dep-check/README.md
@@ -1,0 +1,44 @@
+# Dep Check
+
+Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations.
+
+## What It Does
+
+Performs a comprehensive dependency audit across every ecosystem present in the repository, delivered in 4 steps:
+
+1. **Ecosystem Discovery** -- scans the repository for all dependency manifests, version pins, and infrastructure files across package managers (npm, pip, Cargo, Go, Bundler, Maven/Gradle, Composer, NuGet), CI/CD (GitHub Actions, GitLab CI, CircleCI), infrastructure (Docker, Terraform, Helm), and tooling (.pre-commit, .tool-versions, runtime version files)
+2. **Parallel Dependency Analysis** -- launches 3 parallel agents: Application Dependencies (current vs latest versions via CLI tools or registry APIs), CI/CD and Infrastructure (Actions, Docker base images, Terraform providers, runtime versions), and Security (CVEs via audit tools, breaking change assessments via changelog analysis)
+3. **Prioritized Update Plan** -- structured report with grouped updates ordered by risk (security patches first, then patch/minor/major), exact update commands, and testing recommendations for each group
+4. **Apply Updates** -- offers to apply version updates to manifest files, group by group, with install and test instructions
+
+## Requirements
+
+- Claude Code with **Opus model** access
+- For best results, have ecosystem-specific CLI tools installed (e.g., `npm`, `pip-audit`, `cargo audit`, `gh`). The skill falls back to web registry APIs when CLI tools are unavailable.
+
+## Usage
+
+```
+/dep-check                        # Auto-detect: scan all ecosystems in the repository
+/dep-check package.json           # Check a specific manifest file
+/dep-check src/backend/           # Scan a specific directory
+/dep-check python                 # Check only Python dependencies
+/dep-check docker                 # Check only Docker base image versions
+```
+
+## Configuration
+
+| Setting | Value |
+|---------|-------|
+| Model | `opus` |
+| Effort | `max` |
+| Takes argument | Yes (optional: file path, directory, or ecosystem name) |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion |
+
+## Safety
+
+- **Read-only analysis**: All scanning agents (Step 2) use the Explore subagent type, which cannot modify files
+- **User approval gate**: No manifest files are modified until you review the update plan and explicitly approve changes
+- **Version declarations only**: When applying updates, the skill edits version pins in manifest files -- it does not run install commands (e.g., `npm install`, `pip install`) unless you explicitly ask
+- **No commits or pushes**: The skill never commits, pushes, or publishes -- it only edits local files
+- **Rate-limited web lookups**: When falling back to registry APIs, the skill limits queries to avoid rate limiting and tells you which dependencies were not checked

--- a/skills/dep-check/SKILL.md
+++ b/skills/dep-check/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: dep-check
+description: Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations.
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion
+model: opus
+effort: max
+takes-arg: true
+---
+
+You are performing a comprehensive dependency audit across all ecosystems present in the repository. Scan every dependency and version declaration, check for available updates and known vulnerabilities, and produce a prioritized update plan with testing recommendations.
+
+**ARGUMENTS:** The user may provide an optional scope argument — a specific manifest file path (e.g., `package.json`), a directory to scan, or an ecosystem name (e.g., `npm`, `python`, `docker`). If no argument is provided, auto-detect all ecosystems in the repository.
+
+**IMPORTANT:** Always quote the user-supplied argument in double quotes when passing it to shell commands.
+
+---
+
+## Step 1: Discover Ecosystems and Manifest Files
+
+Scan the repository to identify every dependency declaration and version pin. If an argument was provided, scope the scan accordingly.
+
+**If an argument was provided**, resolve it in this order:
+
+1. **File path** — if the path exists on disk and is a recognized manifest file, scan only that file:
+   ```bash
+   test -f "<path>" && echo "file"
+   ```
+
+2. **Directory path** — if the path is a directory, scan for all manifest files within it:
+   ```bash
+   test -d "<path>" && echo "directory"
+   ```
+
+3. **Ecosystem name** — if the argument matches an ecosystem keyword (`npm`, `yarn`, `pnpm`, `python`, `pip`, `rust`, `cargo`, `go`, `ruby`, `java`, `maven`, `gradle`, `php`, `composer`, `dotnet`, `docker`, `terraform`, `helm`, `actions`, `ci`), scan only files related to that ecosystem.
+
+4. If none of the above match, inform the user and stop:
+   > Could not resolve the argument as a manifest file, directory, or ecosystem name. Try: `/dep-check package.json` (file), `/dep-check src/services/` (directory), or `/dep-check python` (ecosystem).
+
+**If no argument was provided**, scan the entire repository for all of the following manifest files and version declarations. Use the Glob tool to find these files efficiently. Exclude dependency installation directories (`node_modules/`, `vendor/`, `venv/`, `.venv/`, `target/`).
+
+**Package Managers:**
+- npm/yarn/pnpm: `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+- Python: `requirements*.txt`, `pyproject.toml`, `Pipfile`, `Pipfile.lock`, `setup.py`, `setup.cfg`
+- Rust: `Cargo.toml`, `Cargo.lock`
+- Go: `go.mod`, `go.sum`
+- Ruby: `Gemfile`, `Gemfile.lock`
+- Java/Kotlin: `pom.xml`, `build.gradle`, `build.gradle.kts`
+- PHP: `composer.json`, `composer.lock`
+- .NET: `*.csproj`, `Directory.Packages.props`, `Directory.Build.props`
+
+**CI/CD:**
+- GitHub Actions: `.github/workflows/*.yml` (scan for `uses:` directives with version pins)
+- GitLab CI: `.gitlab-ci.yml` (scan for `image:` directives)
+- CircleCI: `.circleci/config.yml` (scan for `image:` and orb versions)
+
+**Infrastructure:**
+- Docker: `Dockerfile*`, `docker-compose*.yml`, `compose*.yml` (scan for `FROM` directives)
+- Terraform: `*.tf`, `.terraform.lock.hcl`
+- Helm: `Chart.yaml`
+
+**Tooling:**
+- `.pre-commit-config.yaml` (hook repo versions)
+- `.tool-versions` (asdf version pins)
+- `.node-version`, `.nvmrc` (Node.js version)
+- `.python-version` (Python version)
+- `.ruby-version` (Ruby version)
+- `dependabot.yml` or `renovate.json` / `renovate.json5` / `.renovaterc` (check configuration completeness)
+
+Read every discovered manifest file and extract all dependencies with their current version constraints.
+
+If no manifest files are found at all, inform the user and stop:
+> No dependency manifests or version declarations found in this repository. This skill requires at least one package manager, CI/CD workflow, or infrastructure file with version pins.
+
+**After discovery**, produce a brief summary listing each detected ecosystem, the manifest files found, and the count of dependencies in each. If the repository spans many ecosystems, ask the user whether to check all of them or focus on specific ones.
+
+---
+
+## Step 2: Parallel Dependency Analysis
+
+Launch **3 Explore subagents in parallel** (`subagent_type: "Explore"`, `model: "opus"`).
+
+Provide each agent with the complete list of discovered manifest files, their full contents, the dependency names, current versions, version constraints, and the detected ecosystems from Step 1.
+
+**IMPORTANT:** All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"`. The Explore agent is read-only by design (Edit and Write are denied at the agent level). This ensures no subagent can accidentally modify the project during analysis.
+
+---
+
+### Agent 1: Application Dependencies — Package Manager Updates
+
+For each package manager ecosystem detected, check every dependency for available updates.
+
+**Use CLI tools when available (preferred — faster and more accurate):**
+
+```bash
+# npm/yarn/pnpm
+npm outdated --json 2>/dev/null
+yarn outdated --json 2>/dev/null
+pnpm outdated --format json 2>/dev/null
+
+# Python
+pip list --outdated --format json 2>/dev/null
+pip-audit --format json 2>/dev/null
+
+# Rust
+cargo outdated --format json 2>/dev/null
+# If cargo-outdated is not installed:
+cargo update --dry-run 2>&1
+
+# Go
+go list -m -u all 2>/dev/null
+
+# Ruby
+bundle outdated --parseable 2>/dev/null
+
+# PHP
+composer outdated --format json 2>/dev/null
+
+# .NET
+dotnet list package --outdated --format json 2>/dev/null
+```
+
+**Fallback when CLI tools are not installed:** Use WebFetch to query package registries directly:
+
+```
+# npm registry
+https://registry.npmjs.org/<package>/latest
+
+# PyPI
+https://pypi.org/pypi/<package>/json
+
+# crates.io
+https://crates.io/api/v1/crates/<package>
+
+# RubyGems
+https://rubygems.org/api/v1/versions/<gem>/latest.json
+
+# Packagist (PHP)
+https://repo.packagist.org/p2/<vendor>/<package>.json
+
+# Go proxy
+https://proxy.golang.org/<module>/@latest
+
+# NuGet
+https://api.nuget.org/v3-flatcontainer/<package>/index.json
+```
+
+Limit WebFetch to **at most 15 dependencies per ecosystem** to avoid rate limiting. Prioritize dependencies that appear to have the oldest pinned versions. For the rest, note that they were not checked due to volume and suggest running the appropriate CLI tool.
+
+**For each dependency, record:**
+- Package name
+- Current version (as declared in the manifest)
+- Latest stable version
+- Version delta category: **patch** (x.x.BUMP), **minor** (x.BUMP.x), or **major** (BUMP.x.x)
+- Whether it is a production dependency or dev/test dependency
+
+If a lockfile is present alongside the manifest, note any discrepancies between the manifest constraint and the locked version.
+
+Return findings as a structured list grouped by ecosystem, then sorted by version delta (major updates first).
+
+---
+
+### Agent 2: CI/CD and Infrastructure Versions
+
+Check all non-package-manager version declarations for available updates.
+
+**GitHub Actions:**
+For each `uses:` directive in workflow files (e.g., `actions/checkout@v4`):
+- Extract the action name and pinned version (tag, branch, or SHA)
+- Check the latest release via:
+  ```bash
+  gh api repos/<owner>/<action>/releases/latest --jq '.tag_name' 2>/dev/null
+  ```
+  Or fall back to WebFetch: `https://api.github.com/repos/<owner>/<action>/releases/latest`
+- Flag any actions pinned to a branch (e.g., `@main`) instead of a tag or SHA
+- Flag any actions pinned to a major-only tag (e.g., `@v4`) vs a full SHA — note this as a style choice, not an error
+
+**Docker base images:**
+For each `FROM` directive in Dockerfiles:
+- Extract the image name and tag
+- If the tag is `latest`, flag as unpinned
+- If the tag is a version, check for newer versions via:
+  ```bash
+  skopeo list-tags docker://docker.io/<image> 2>/dev/null | head -20
+  ```
+  Or fall back to WebFetch: `https://hub.docker.com/v2/repositories/library/<image>/tags/?page_size=10&ordering=last_updated`
+  Or use WebSearch as a last resort
+- Flag images using deprecated or EOL base versions (e.g., `node:14`, `python:3.7`, `ubuntu:18.04`)
+
+**Terraform providers:**
+For each `required_providers` block in `.tf` files:
+- Extract provider name and version constraint
+- Check latest via WebFetch: `https://registry.terraform.io/v1/providers/<namespace>/<provider>/versions`
+
+**Helm chart dependencies:**
+For each dependency in `Chart.yaml`:
+- Extract chart name, repository, and version
+- Note the current version for manual verification
+
+**Pre-commit hooks:**
+For each `repo` entry in `.pre-commit-config.yaml`:
+- Extract the repo URL and `rev` (version tag)
+- Check latest tag via:
+  ```bash
+  gh api repos/<owner>/<repo>/releases/latest --jq '.tag_name' 2>/dev/null
+  ```
+
+**Runtime version files** (`.tool-versions`, `.node-version`, `.python-version`, `.ruby-version`, `.nvmrc`):
+- Extract the pinned version
+- Check whether it is still actively supported (not EOL) using WebSearch if needed
+- Note the current LTS version for comparison
+
+**Dependency update tool configuration** (`dependabot.yml`, `renovate.json`):
+- Check which ecosystems are configured for automatic updates
+- Identify ecosystems present in the repo that are NOT covered by the update tool configuration
+- Report missing coverage as a finding
+
+Return findings as a structured list grouped by category (Actions, Docker, Terraform, Helm, Tooling, Update Tool Coverage).
+
+---
+
+### Agent 3: Security Vulnerabilities and Breaking Changes
+
+Scan for known security vulnerabilities and assess breaking change risk for major updates.
+
+**Use CLI audit tools when available (preferred):**
+
+```bash
+# npm
+npm audit --json 2>/dev/null
+
+# Python
+pip-audit --format json 2>/dev/null
+# Or: safety check --json 2>/dev/null
+
+# Rust
+cargo audit --json 2>/dev/null
+
+# Ruby
+bundle audit check 2>/dev/null
+# Or: bundler-audit check 2>/dev/null
+
+# Go
+govulncheck ./... 2>/dev/null
+
+# PHP
+composer audit --format json 2>/dev/null
+
+# .NET
+dotnet list package --vulnerable --format json 2>/dev/null
+```
+
+**Fallback when CLI audit tools are not installed:** Use WebSearch to query vulnerability databases:
+- Search: `<package> <version> CVE vulnerability`
+- Check: `https://github.com/advisories?query=<package>` (via WebFetch to the GitHub Advisory Database API)
+
+**For each vulnerability found, record:**
+- Package name and affected version range
+- CVE identifier (if available)
+- Severity: **critical**, **high**, **medium**, **low**
+- Brief description of the vulnerability
+- Fixed-in version (the minimum version that resolves it)
+- Whether the vulnerability is in a production or dev dependency
+
+**Breaking change assessment:**
+For dependencies with major version updates available (identified by Agent 1), assess the breaking change risk:
+- Use WebSearch to find the changelog or migration guide: `<package> <current_major> to <latest_major> migration guide`
+- Categorize the effort: **drop-in** (likely no code changes needed), **minor migration** (configuration or import changes), **significant migration** (API changes requiring code rewrites)
+- Note any dependencies that have been deprecated or archived
+
+Return findings as two structured lists:
+1. **Vulnerabilities** — sorted by severity (critical first)
+2. **Breaking change assessments** — for each major update, with migration effort estimate
+
+---
+
+## Step 3: Synthesize Update Plan
+
+Collect all findings from the 3 agents and produce a single, structured dependency report with a prioritized update plan.
+
+**Synthesis rules:**
+- **Deduplicate**: If multiple agents flagged the same dependency, merge into one entry with combined context.
+- **Prioritize**: Security vulnerabilities first, then EOL runtimes, then patch, minor, and major updates.
+- **Group updates**: Combine updates that should be applied and tested together (e.g., all `@testing-library/*` packages, all AWS SDK packages, related Terraform providers).
+- **Be specific**: Every finding must reference the exact manifest file, dependency name, current version, and target version.
+- **Be actionable**: Every update group must include the exact commands to apply the update and test it.
+
+**Use this report format:**
+
+```
+## Dependency Report: <repository name>
+
+**Scanned**: <N manifest files> across <M ecosystems> | **Dependencies**: <total count>
+**Updates available**: <count> | **Vulnerabilities**: <count> (<X critical, Y high, Z medium>)
+
+---
+
+### Security Vulnerabilities (act immediately)
+
+**[V1]** `<package>` <current_version> — <CVE-ID>: <brief description>
+Severity: **critical** | File: `<manifest_path>`
+Fixed in: `<fixed_version>`
+Update command:
+\`\`\`
+<exact command to update>
+\`\`\`
+
+(repeat for each vulnerability)
+
+---
+
+### Update Plan
+
+Updates are grouped for safe, incremental application. Apply and test each group before proceeding to the next.
+
+#### Group 1: Security patches (no breaking changes expected)
+**Risk**: Low | **Effort**: Minimal
+
+| Package | Current | Target | Delta | File |
+|---------|---------|--------|-------|------|
+| pkg-a   | 1.2.3   | 1.2.5  | patch | package.json |
+
+**Apply:**
+\`\`\`
+<exact command(s) to apply these updates>
+\`\`\`
+
+**Test:**
+- Run `<test command>` to verify no regressions
+- <specific areas to smoke-test based on what these packages do>
+
+#### Group 2: Minor updates (backward-compatible)
+**Risk**: Low-Medium | **Effort**: Minimal
+
+(same table + apply + test format)
+
+#### Group 3: Major updates (breaking changes possible)
+**Risk**: Medium-High | **Effort**: <estimated effort>
+
+| Package | Current | Target | Delta | Migration |
+|---------|---------|--------|-------|-----------|
+| pkg-x   | 2.1.0   | 3.0.0  | major | Minor migration — see changelog |
+
+**Apply:**
+\`\`\`
+<commands>
+\`\`\`
+
+**Test:**
+- <specific testing recommendations based on what changed>
+
+**Migration notes:**
+- <specific breaking changes and how to address them>
+
+#### Group N: CI/CD and infrastructure updates
+**Risk**: <varies> | **Effort**: <varies>
+
+| Component | Current | Target | Type | File |
+|-----------|---------|--------|------|------|
+| actions/checkout | v4 | v6 | GitHub Action | .github/workflows/ci.yml |
+
+**Apply:**
+<exact file edits needed>
+
+**Test:**
+- <CI/CD testing recommendations>
+
+---
+
+### Already Up to Date
+
+<count> dependencies are already at their latest version.
+
+---
+
+### Not Checked
+
+<list any dependencies that could not be checked, with reasons (e.g., private registry, CLI tool not installed, rate limit)>
+If applicable: To check these, install `<tool>` and re-run, or run: `<manual command>`
+
+---
+
+### Dependency Update Tool Coverage
+
+<If dependabot.yml or renovate.json exists>:
+- Configured ecosystems: <list>
+- Missing ecosystems: <list of ecosystems present in repo but not covered>
+- Recommendation: <what to add to the configuration>
+
+<If no dependency update tool is configured>:
+- **Recommendation**: Configure Dependabot or Renovate to automate dependency updates. Here is a starter configuration covering all detected ecosystems:
+\`\`\`yaml
+<dependabot.yml or renovate.json snippet>
+\`\`\`
+```
+
+**Priority logic for grouping:**
+1. **Security patches** — vulnerabilities with fixes available, especially in production dependencies
+2. **EOL runtime versions** — Node.js, Python, Ruby, etc. versions past end-of-life
+3. **Patch updates** — safe, low-risk version bumps
+4. **Minor updates** — backward-compatible feature releases
+5. **Major updates** — ordered by migration effort (easiest first)
+6. **CI/CD and infrastructure** — Actions, Docker, Terraform versions
+
+---
+
+## Step 4: Offer to Apply Updates
+
+After presenting the report, if there are any updates available, ask:
+
+> **Want me to apply any of these updates?** (e.g., "apply all", "apply group 1", "apply security patches only", "apply V1 and V3")
+
+If the user requests updates:
+
+1. Apply updates group by group in the order specified.
+2. For package manager updates, use the appropriate CLI command:
+   ```bash
+   # npm
+   npm install <package>@<version>
+
+   # Python (requirements.txt) — edit the version pin directly
+   # Python (pyproject.toml / Pipfile) — edit the version constraint
+
+   # Rust
+   cargo update -p <package>
+
+   # Go
+   go get <module>@<version>
+
+   # Ruby
+   bundle update <gem>
+
+   # PHP
+   composer require <package>:<version>
+   ```
+3. For CI/CD and infrastructure updates, use the Edit tool to modify version pins in the relevant files.
+4. After applying each group, show a summary of what changed:
+   > **Applied Group 1**: Updated 3 packages in `package.json`. Run `<test command>` to verify.
+5. Do NOT run install commands (`npm install`, `pip install`, etc.) or test commands automatically — only update the version declarations in the manifest files. Tell the user what commands to run:
+   > I've updated the version declarations. Run `<install command>` to install the new versions, then `<test command>` to verify.
+
+If the report shows zero updates and zero vulnerabilities, skip the update offer:
+> All dependencies are up to date and no known vulnerabilities were found.


### PR DESCRIPTION
## Summary

- Adds `dep-check` skill: scans all dependency declarations across ecosystems (npm, pip, Cargo, Go, Ruby, Java, PHP, .NET, GitHub Actions, Docker, Terraform, Helm, pre-commit, runtime version files) for updates and vulnerabilities, produces a prioritized update plan with testing recommendations
- Updates skills table in README.md and adds changelog entry

Closes #30

## Test plan

- [x] `./lint.sh dep-check` passes (12/12 checks)
- [x] `./install.sh dep-check` creates symlink correctly
- [x] Smoke test `/dep-check` in a project with dependencies