### PR TITLE
Add plan mode to all skills

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: code-review
 description: Structured code review across correctness, security, performance, and conventions with prioritized findings and fix offers.
-allowed-tools: Read, Grep, Glob, Bash, Agent
+allowed-tools: Read, Grep, Glob, Bash, Agent, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
 ---
+
+Call `EnterPlanMode` immediately before doing anything else.
 
 You are performing a comprehensive, structured code review. Analyze code changes across multiple quality dimensions and produce a clear, prioritized findings report.
 
@@ -225,7 +227,9 @@ Collect all findings from the 3 agents and produce a single, structured report.
 
 ## Step 4: Offer Remediation
 
-After presenting the report, if there are any Critical or Warning findings, ask:
+After presenting the report, call `ExitPlanMode`.
+
+If there are any Critical or Warning findings, ask:
 
 > **Want me to fix any of these?** (e.g., "fix all", "fix C1 and W2", "fix all critical")
 

--- a/skills/dep-check/SKILL.md
+++ b/skills/dep-check/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: dep-check
 description: Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations.
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
 ---
+
+Call `EnterPlanMode` immediately before doing anything else.
 
 You are performing a comprehensive dependency audit across all ecosystems present in the repository. Scan every dependency and version declaration, check for available updates and known vulnerabilities, and produce a prioritized update plan with testing recommendations.
 
@@ -440,3 +442,7 @@ If the user requests updates:
 
 If the report shows zero updates and zero vulnerabilities, skip the update offer:
 > All dependencies are up to date and no known vulnerabilities were found.
+
+---
+
+Once the report is presented (and any requested updates are applied), call `ExitPlanMode`.

--- a/skills/test-gen/SKILL.md
+++ b/skills/test-gen/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: test-gen
 description: Analyzes code to generate comprehensive tests covering happy paths, edge cases, error handling, and integration points, matching the project's existing test conventions.
-allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write
+allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
 ---
+
+Call `EnterPlanMode` immediately before doing anything else.
 
 You are generating comprehensive, high-quality tests for a codebase. Analyze the target code deeply, detect the project's test framework and conventions, present a structured test plan, and — after user approval — write the test files and verify they pass.
 
@@ -236,7 +238,7 @@ Covers: <what behavior or code path this validates>
 - `<function_name>` — <scenario> (covered by `<test_file_path>:<line>`)
 ```
 
-After presenting the test plan, ask:
+After presenting the test plan, call `ExitPlanMode`, then ask:
 
 > **Ready to generate these tests?** (e.g., "yes", "skip T5 and T7", "only critical", "add a test for <scenario>")
 


### PR DESCRIPTION
## Summary
- Add `EnterPlanMode`/`ExitPlanMode` to `code-review`, `dep-check`, and `test-gen` skills
- Each skill now enters plan mode before analysis and exits before the action phase (applying fixes, writing tests, applying updates)
- `enhance` and `github-audit` already had this — now all skills are consistent

Closes #33

## Test plan
- [x] Invoke `/code-review` and verify it enters plan mode
- [x] Invoke `/dep-check` and verify it enters plan mode
- [x] Invoke `/test-gen` and verify it enters plan mode
- [x] Verify `/enhance` and `/github-audit` still work as before