### PR TITLE
Rename debug skill to diagnose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Added
-- `debug` skill: multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses
+- `diagnose` skill (renamed from `debug` to avoid conflict with built-in Claude Code command): multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses
 
 ## [0.0.4] - 2026-03-29
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A curated collection of custom skills for [Claude Code](https://docs.anthropic.c
 | [code-review](skills/code-review/) | Structured code review with prioritized findings and fix offers | Opus | Max |
 | [test-gen](skills/test-gen/) | Comprehensive test generation with deep code analysis, convention detection, and edge case coverage | Opus | Max |
 | [dep-check](skills/dep-check/) | Scans dependencies across ecosystems for updates and vulnerabilities, produces a prioritized update plan | Opus | Max |
-| [debug](skills/debug/) | Multi-agent root cause analysis with error tracing, change correlation, and ranked fix hypotheses | Opus | Max |
+| [diagnose](skills/diagnose/) | Multi-agent root cause analysis with error tracing, change correlation, and ranked fix hypotheses | Opus | Max |
 
 ## Quick Start
 
@@ -44,7 +44,7 @@ Once installed, invoke any skill inside Claude Code:
 > /code-review src/auth/
 > /test-gen src/utils.ts
 > /dep-check
-> /debug TypeError: Cannot read properties of undefined
+> /diagnose TypeError: Cannot read properties of undefined
 ```
 
 ## How It Works

--- a/skills/diagnose/README.md
+++ b/skills/diagnose/README.md
@@ -1,4 +1,4 @@
-# Debug
+# Diagnose
 
 Multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses.
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: debug
+name: diagnose
 description: Multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses.
 allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode
 model: opus


### PR DESCRIPTION
## Summary

- Rename `debug` → `diagnose` to avoid conflict with the built-in Claude Code `/debug` command
- Update directory name, SKILL.md frontmatter, README title, root README skills table, and CHANGELOG

## Checklist

- [x] `./lint.sh` passes with no errors
- [x] Skill `name` field matches directory name
- [x] `README.md` has all required sections (What It Does, Requirements, Usage, Configuration)
- [x] Skills table in root `README.md` is updated
- [x] `CHANGELOG.md` is updated