### PR TITLE
Release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.0.6] - 2026-04-01
+
 ### Added
 - `create-skill` skill: interactive skill generator that scaffolds new skills following all project conventions, serving as the definitive reference for skill creation
 
@@ -54,7 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - README.md with badges, usage example, contributing section, and support info
 - .gitignore with defensive entries for .env, logs, node_modules, and __pycache__
 
-[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.5...HEAD
+[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.6...HEAD
+[0.0.6]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.2...v0.0.3


### PR DESCRIPTION
## Summary
- Cut v0.0.6 release: moves `create-skill` from Unreleased to 0.0.6 in CHANGELOG
- Updates comparison links