### PR TITLE
Release v0.0.8: Opus 4.7 doc bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-04-23
+
+### Changed
+- Updated Opus 4.6 references to Opus 4.7 across all skill docs and the bug report template (Claude bumped the Opus model version; no functional change — `model: opus` still resolves to the current Opus)
+
 ## [0.0.7] - 2026-04-23
 
 ### Added
@@ -61,7 +66,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - README.md with badges, usage example, contributing section, and support info
 - .gitignore with defensive entries for .env, logs, node_modules, and __pycache__
 
-[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.7...HEAD
+[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.8...HEAD
+[0.0.8]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.4...v0.0.5


### PR DESCRIPTION
## Summary

Cuts **v0.0.8**, a docs-only patch that follows up #45 (Opus 4.6 → 4.7 reference update).

- Moves the `### Changed` entry from `[Unreleased]` to a dated `[0.0.8] - 2026-04-23` section
- Updates the compare links

Matches the release flow used for v0.0.5 / v0.0.6 / v0.0.7 (CHANGELOG-only, tag-triggered GitHub Release via `.github/workflows/release.yml`).

## Release flow after merge

1. Tag the merge commit: `git tag v0.0.8 && git push origin v0.0.8`
2. `.github/workflows/release.yml` fires on the `v*` tag, extracts the `## [0.0.8]` section from CHANGELOG.md, and creates the GitHub Release automatically.

## Test plan

- [x] `## [0.0.8] - 2026-04-23` heading inserted between `[Unreleased]` and `[0.0.7]`
- [x] `[Unreleased]` compare link updated from `v0.0.7...HEAD` → `v0.0.8...HEAD`
- [x] `[0.0.8]: .../compare/v0.0.7...v0.0.8` link added
- [x] `./lint.sh` still passes (no skill content changed)
- [ ] After merge: push `v0.0.8` tag and verify the Release workflow extracts the correct notes