### PR TITLE
Add github-ship skill for GitHub issue and PR automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- `github-ship` skill: turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged — auto-detects which
+
 ## [0.0.8] - 2026-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated collection of custom skills for [Claude Code](https://docs.anthropic.c
 | [refactor](skills/refactor/) | Comprehensive refactoring across correctness, security, performance, and maintainability with behavior-preserving changes | Opus | Max |
 | [create-skill](skills/create-skill/) | Interactive skill generator that scaffolds new skills following all project conventions | Opus | Max |
 | [docstring-check](skills/docstring-check/) | Scans a codebase for missing, outdated, drifted, or inconsistent docstrings and applies convention-matching fixes | Opus | Max |
+| [github-ship](skills/github-ship/) | Turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged. Auto-detects which | Opus | Max |
 
 ## Quick Start
 
@@ -51,6 +52,7 @@ Once installed, invoke any skill inside Claude Code:
 > /refactor src/auth/handler.ts
 > /create-skill "API documentation generator"
 > /docstring-check src/
+> /github-ship
 ```
 
 ## How It Works

--- a/skills/github-ship/README.md
+++ b/skills/github-ship/README.md
@@ -1,0 +1,60 @@
+# GitHub Ship
+
+Turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged. Auto-detects which.
+
+## What It Does
+
+You make changes, run `/github-ship`, approve the proposed issue + PR — the skill creates both. You merge the PR on GitHub yourself. Run `/github-ship` again and, because it now sees a merged PR on the current branch, it switches to cleanup and tears down the feature branch.
+
+One command, no arguments, one mental model.
+
+1. **Pre-flight** — checks git repo, GitHub remote, `gh` auth. Resolves default branch. Looks up any existing PR for the current branch.
+2. **Decide** — merged PR exists → cleanup. Otherwise → create.
+3. **Create** — reads the diff and commits, drafts issue title/body, PR title/body (with `Closes #N`), commit message (if dirty), branch name (if on default). Shows the plan, asks for approval, then runs commit → branch → push → `gh issue create` → `gh pr create`.
+4. **Cleanup** — verifies the PR is merged, checks out default, `git pull --ff-only`, deletes the local and remote feature branches.
+
+## Requirements
+
+- Claude Code with **Opus model** access
+- Git repository with a `github.com` remote named `origin`
+- [GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated (`gh auth login`)
+
+## Usage
+
+```
+/github-ship
+```
+
+Typical flow:
+
+```
+# 1. Claude Code makes changes in your repo.
+# 2. You run:
+/github-ship
+# Review the proposed issue + PR, approve. The skill creates both.
+
+# 3. You go to GitHub and merge the PR manually.
+
+# 4. Run it again:
+/github-ship
+# It sees the merged PR, switches to cleanup, and deletes the branch.
+```
+
+## Configuration
+
+| Setting | Value |
+|---------|-------|
+| Model | `opus` |
+| Effort | `max` |
+| Takes argument | No |
+| Allowed tools | Read, Grep, Glob, Bash, AskUserQuestion, EnterPlanMode, ExitPlanMode |
+
+No `Edit` or `Write` — all changes run through `git` or `gh`.
+
+## Safety
+
+- **User approval gate**: Nothing runs until you approve the plan via `ExitPlanMode`
+- **Manual merge, always**: The skill never calls `gh pr merge`
+- **Force-delete confirmation**: Deleting a local branch with unmerged commits (common with squash-merged PRs) requires a second inline confirmation
+- **Dirty tree refusal**: Cleanup stops if the working tree has uncommitted changes
+- **No hook bypass**: Commits never use `--no-verify`; if a pre-commit hook fails, the skill stops and surfaces the error

--- a/skills/github-ship/SKILL.md
+++ b/skills/github-ship/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: github-ship
+description: Turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged. Auto-detects which.
+allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion, EnterPlanMode, ExitPlanMode
+model: opus
+effort: max
+---
+
+Call `EnterPlanMode` immediately before doing anything else.
+
+You automate a GitHub issue + PR workflow. The user runs you with no arguments. You look at the current branch and figure out what to do:
+
+- If there is a merged PR for the current branch → **clean up** the branch.
+- Otherwise → **create** an issue and a linked PR for the local changes.
+
+You never merge the PR yourself — that is always the user's action on GitHub.
+
+---
+
+## Step 1: Pre-flight and Decide
+
+Check the environment. Stop with an actionable error on any failure.
+
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null || echo "not_a_repo"
+git remote get-url origin 2>/dev/null | grep -qE 'github\.com[:/]' || echo "no_github_remote"
+gh auth status 2>&1 | grep -q "Logged in" || echo "gh_not_authenticated"
+```
+
+Resolve the default branch:
+
+```bash
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$default_branch" ] && git rev-parse --verify main >/dev/null 2>&1 && default_branch=main
+[ -z "$default_branch" ] && git rev-parse --verify master >/dev/null 2>&1 && default_branch=master
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+```
+
+Check whether a PR already exists for the current branch:
+
+```bash
+gh pr list --head "$current_branch" --state all --json number,state,mergedAt,url --limit 1 2>/dev/null
+```
+
+- If the PR state is `MERGED` → go to **Step 3 (Cleanup)**.
+- Otherwise → go to **Step 2 (Create)**. If a non-merged PR already exists, note that in the plan and offer to update it rather than create a new one.
+
+---
+
+## Step 2: Create — Draft, Approve, Execute
+
+Gather the change:
+
+```bash
+git status --porcelain
+git log "$default_branch"..HEAD --format="%h %s"
+git diff "$default_branch"...HEAD --stat
+git diff "$default_branch"...HEAD
+git diff HEAD
+```
+
+Read the full content of any non-trivial files in the diff so your descriptions are accurate.
+
+Draft these yourself:
+
+- **Issue title** (≤70 chars, imperative mood, no trailing period).
+- **Issue body** (2-4 sentences describing the problem or need).
+- **PR title** (≤70 chars).
+- **PR body**: starts with `Closes #<N>` (placeholder until the issue is created), then a Summary (bullets) and Test plan (checklist).
+- **Branch name** (kebab-case, prefixed `fix/`, `feat/`, `chore/`, `docs/`, or `refactor/`) — only if currently on the default branch.
+- **Commit message** (imperative, ≤72 chars) — only if there are uncommitted changes.
+
+Present the plan:
+
+```
+## Ship Plan
+
+**On**: `<current_branch>` → `<default_branch>` on `<repo>`
+
+### Actions
+
+- [<x or space>] Commit: `<commit message>`          (skip if nothing uncommitted)
+- [<x or space>] Create branch: `<branch name>`      (skip if already on a feature branch)
+- [<x or space>] Push to origin
+- [ ] Create issue
+- [ ] Create PR linking to the issue
+
+### Issue
+
+**Title**: <title>
+**Body**:
+> <body>
+
+### Pull Request
+
+**Title**: <title>
+**Body**:
+> Closes #<N>
+>
+> ## Summary
+> <bullets>
+>
+> ## Test plan
+> <checklist>
+```
+
+Call `ExitPlanMode`, then ask:
+
+> **Ship it?** (e.g., "go", "shorten the title", "rewrite the body")
+
+After approval, execute in order. If any step fails, stop and report.
+
+1. Commit if needed:
+   ```bash
+   git add -A && git commit -m "<commit message>"
+   ```
+   Never use `--no-verify`.
+
+2. Create a feature branch if currently on `$default_branch`:
+   ```bash
+   git checkout -b "<branch name>"
+   ```
+
+3. Push:
+   ```bash
+   git push -u origin HEAD
+   ```
+
+4. Create the issue and capture the number:
+   ```bash
+   issue_url=$(gh issue create --title "<title>" --body "$(cat <<'EOF'
+   <issue body>
+   EOF
+   )")
+   issue_number=$(echo "$issue_url" | grep -oE '[0-9]+$')
+   ```
+
+5. Create the PR:
+   ```bash
+   gh pr create --base "$default_branch" --title "<pr title>" --body "$(cat <<EOF
+   Closes #$issue_number
+
+   ## Summary
+   <bullets>
+
+   ## Test plan
+   <checklist>
+   EOF
+   )"
+   ```
+
+6. Report:
+   > **Shipped.**
+   > - Issue: `<issue_url>`
+   > - PR: `<pr_url>`
+   >
+   > Merge the PR on GitHub when ready, then run `/github-ship` again to clean up.
+
+---
+
+## Step 3: Cleanup — Verify, Approve, Execute
+
+Verify the state:
+
+```bash
+git status --porcelain    # must be clean
+gh pr view --json number,state,mergedAt,headRefName,url 2>/dev/null
+```
+
+If the working tree is dirty, stop: `Commit or stash your changes before cleanup.`
+
+Present the cleanup plan:
+
+```
+## Ship Cleanup
+
+**PR**: #<N> merged (<url>)
+**Branch**: `<current_branch>`
+
+### Actions
+
+1. Checkout `<default_branch>`
+2. `git pull --ff-only`
+3. Delete local branch `<current_branch>`
+4. Delete remote branch `<current_branch>` (if it still exists)
+```
+
+Call `ExitPlanMode`, then ask:
+
+> **Clean up?** ("go" / "no")
+
+After approval:
+
+```bash
+git checkout "$default_branch"
+git pull --ff-only
+git branch -d "$current_branch" 2>&1
+```
+
+If `git branch -d` refuses with "not fully merged" (normal for squash-merged or rebase-merged PRs), ask inline:
+
+> Local branch has commits not on `<default>`. This is normal for squash/rebase merges. Force-delete? (yes/no)
+
+If yes:
+```bash
+git branch -D "$current_branch"
+```
+
+Then delete the remote branch if it still exists:
+```bash
+if git ls-remote --heads origin "$current_branch" | grep -q .; then
+  git push origin --delete "$current_branch"
+fi
+```
+
+Report:
+> **Cleaned up.** On `<default_branch>` at `<sha>`. Branch `<current_branch>` removed.


### PR DESCRIPTION
Closes #47

## Summary

- Adds a new `github-ship` skill that turns local changes into a GitHub issue + linked PR, or cleans up the branch if the PR was already merged — auto-detects which.
- Three-step workflow: pre-flight (repo / GitHub remote / `gh` auth + default-branch resolution + existing-PR lookup) → create (draft issue/PR/commit/branch, approve via `ExitPlanMode`, execute) → cleanup (verify merged PR, delete local + remote branch).
- Minimal permissions: `Read, Grep, Glob, Bash, AskUserQuestion, EnterPlanMode, ExitPlanMode`. No `Edit` / `Write` — all mutations run through `git` or `gh`.
- Safety rails: user approval gate before any mutation, force-delete confirmation for squash/rebase-merged branches, dirty-tree refusal on cleanup, no `--no-verify` on commit, skill never calls `gh pr merge`.

## Files changed

- `skills/github-ship/SKILL.md` (new) — 3-step skill body
- `skills/github-ship/README.md` (new) — all 6 required sections (Title, What It Does, Requirements, Usage, Configuration, Safety)
- `README.md` — new row in the skills table, new `/github-ship` entry in the Quick Start usage block
- `CHANGELOG.md` — `### Added` entry under `[Unreleased]`

## Test plan

- [ ] `./lint.sh github-ship` passes all checks
- [ ] `./lint.sh` (all skills) passes with no regressions
- [ ] `./install.sh github-ship` creates a symlink at `~/.claude/skills/github-ship`
- [ ] Invoke `/github-ship` on a feature branch with local changes → verify the create flow (issue created, PR created with `Closes #N` link, branch pushed)
- [ ] After manually merging the PR on GitHub, re-invoke `/github-ship` → verify the cleanup flow (default branch checked out, `git pull --ff-only` succeeds, local + remote feature branches deleted)