### PR TITLE
Release v0.0.9: github-ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.0.9] - 2026-04-24
+
 ### Added
 - `github-ship` skill: turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged — auto-detects which
 
@@ -69,7 +71,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - README.md with badges, usage example, contributing section, and support info
 - .gitignore with defensive entries for .env, logs, node_modules, and __pycache__
 
-[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.8...HEAD
+[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.9...HEAD
+[0.0.9]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.5...v0.0.6


### PR DESCRIPTION
## Summary

Cuts **v0.0.9**, which ships the new `github-ship` skill.

- Moves the `### Added` entry from `[Unreleased]` into a dated `[0.0.9] - 2026-04-24` section
- Updates the compare links

Matches the release flow used for v0.0.5 / v0.0.6 / v0.0.7 / v0.0.8 (CHANGELOG-only, tag-triggered GitHub Release via `.github/workflows/release.yml`).

## Release flow after merge

1. Tag the merge commit: `git tag v0.0.9 && git push origin v0.0.9`
2. `.github/workflows/release.yml` fires on the `v*` tag, extracts the `## [0.0.9]` section from `CHANGELOG.md`, and creates the GitHub Release automatically.

## Test plan

- [x] `## [0.0.9] - 2026-04-24` heading inserted between `[Unreleased]` and `[0.0.8]`
- [x] `[Unreleased]` compare link updated from `v0.0.8...HEAD` → `v0.0.9...HEAD`
- [x] `[0.0.9]: .../compare/v0.0.8...v0.0.9` link added
- [x] `./lint.sh` still passes (no skill content changed)
- [x] After merge: push `v0.0.9` tag and verify the Release workflow extracts the correct notes