### PR TITLE
Refresh all skills with modern Claude Code best practices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+- `dep-check`: `ExitPlanMode` was called AFTER Step 4 attempted manifest edits, which made the apply phase unreachable while plan mode was still active. Moved the call to the end of Step 3 (before the action offer).
+- `diagnose` README: every Usage example invoked `/debug` (the pre-rename name), which would either fail or hit a different built-in command. Replaced with `/diagnose`.
+- `github-audit`: several `gh api repos/{owner}/{repo}/...` calls relied on placeholder substitution that `gh api` does not perform, returning 404 at runtime. Now resolves `nameWithOwner` and the default branch explicitly via `gh repo view` and substitutes them into each subsequent API call.
+- `github-ship`: the PR-body heredoc used an unquoted `<<EOF` delimiter, allowing `$variable`, backtick, and `$(...)` expansion inside the body — a shell-substitution injection risk if the body included quoted code snippets. Switched to a quoted `<<'EOF'` body with `$issue_number` interpolated separately, piped via `--body-file -`.
+- `github-ship`: branch cleanup unconditionally deleted the remote branch even after the user declined a force-delete on the local one. Remote delete is now gated on local-delete success or explicit user approval.
+- `diagnose`: shell snippets contained literal placeholders (`<id>`, `<error_file_1>`, `<error_file_N>`, `<error_keywords>`) that would be passed unchanged if the model didn't pattern-match. Replaced with explicit `jq` extraction (`run_id`, `commit_hash`) and per-path loops.
+- `refactor` and `docstring-check`: pre-change backup used `git stash push`, which exits 0 even when there's nothing to stash — a later `git stash pop` could pop an unrelated stash. Switched to `git stash create` + `git stash store` so the backup is captured by SHA.
+- `dep-check`: Step 4 mixed "run `npm install <package>@<version>`" guidance with a "do NOT run install commands" rule. Now consistently edits manifests via `Edit` and instructs the user to run install/test themselves. Version/package arguments in suggested commands are quoted.
+
+### Changed
+- **Meta-skill overhaul (`create-skill`).** R4 (Subagents) now defaults to NO subagents and adds a Decision Gate: skills only fan out to 3 Explore agents when there are three genuinely orthogonal analysis lenses. This aligns the meta-skill with the project's simplicity bias (e.g., `github-ship`). R2 (Tool Selection) now documents modern primitives — `TaskCreate`/`TaskUpdate`, `Monitor`, `Skill`, `CronCreate`, `LSP` — and when to add each. Step 1 now batches the structured questions into an explicit `AskUserQuestion` call. R11 codifies "delivered in N steps" wording and verbatim-match between SKILL.md description and README first line.
+- **`CLAUDE.md`**: clarified `disable-model-invocation` semantics (controls auto-invocation by other models/skills, does NOT block subagents); added Simplicity Bias and Plan-Mode Discipline to Quality Standards.
+- **Templates** (`templates/SKILL.md`, `templates/README.md`): regenerated to reflect canonical opening line, default tool set (no `Agent` by default), and full Configuration table including `Takes argument`.
+- **Consistency pass.** `enhance` and `github-audit` SKILL.md now use the canonical `` Call `EnterPlanMode` immediately before doing anything else. `` opening (was an older "Step 1: Enter Plan Mode..." phrasing). `github-audit` agent subheadings switched from bold inline text to `### Agent N:`. `enhance`, `github-audit`, `test-gen`, `code-review` now carry the full canonical IMPORTANT subagent block (Explore + Opus + safety reasoning). `enhance` SKILL.md phases renumbered to 1-6 (was 1, 1.5, 2-5); README phase list updated to match. `enhance` description shortened to one sentence and aligned across SKILL.md / README / root README. `enhance` allowed-tools no longer declares `LSP` (was unused).
+- **Configuration tables** in all skill READMEs now list the exact same tools as the SKILL.md `allowed-tools` frontmatter (previously some omitted `EnterPlanMode`/`ExitPlanMode`). `github-audit` and `enhance` READMEs gained the `Takes argument | No` row.
+- **`test-gen`** allowed-tools gained `AskUserQuestion` (the skill prompts the user mid-flow); SKILL.md gained the canonical IMPORTANT subagent block.
+
+### Added
+- **Modern primitives wired into looping skills.** `idiom-check`, `dep-check`, `docstring-check`, and `refactor` now use `TaskCreate`/`TaskUpdate` during their execution phases so the user sees live progress through multi-unit work (one task per bundle / update group / file / refactoring finding). `TaskCreate, TaskUpdate` added to each skill's `allowed-tools`.
+- **`github-audit`** can now hand off to other installed skills via the `Skill` tool when a recommendation maps cleanly to another skill (e.g., dependency hygiene → `/dep-check`). `Skill` added to allowed-tools.
+- **`dep-check`** Step 2 now mandates parallel `Bash` tool calls for the per-ecosystem `outdated`/`audit`/`list` sweep, with `timeout 60` per command and explicit recording of which invocations timed out vs were unavailable vs returned empty.
+- **`lint.sh`** gained 6+ new regression-prevention checks: description ends with a period; matched `EnterPlanMode`/`ExitPlanMode` pairs in frontmatter and body references; canonical IMPORTANT subagent block presence when `Agent` is used with Explore subagents; README line 3 matches SKILL.md description; Usage examples invoke the correct `/<name>`; Configuration table includes `Takes argument` and `Allowed tools` rows; allowed-tools parity between SKILL.md frontmatter and README Configuration table.
+
 ## [0.0.10] - 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-14
+
 ### Fixed
 - `dep-check`: `ExitPlanMode` was called AFTER Step 4 attempted manifest edits, which made the apply phase unreachable while plan mode was still active. Moved the call to the end of Step 3 (before the action offer).
 - `diagnose` README: every Usage example invoked `/debug` (the pre-rename name), which would either fail or hit a different built-in command. Replaced with `/diagnose`.
@@ -100,7 +102,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - README.md with badges, usage example, contributing section, and support info
 - .gitignore with defensive entries for .env, logs, node_modules, and __pycache__
 
-[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.10...HEAD
+[Unreleased]: https://github.com/thijsvos/Claude_Skills/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.10...v0.1.0
 [0.0.10]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/thijsvos/Claude_Skills/compare/v0.0.7...v0.0.8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Every `SKILL.md` must begin with YAML frontmatter between `---` delimiters.
 |-------|---------|-------------|
 | `model` | (inherits) | Model to use: `opus`, `sonnet`, or `haiku` |
 | `effort` | (inherits) | Effort level: `min`, `low`, `medium`, `high`, `max` |
-| `disable-model-invocation` | `false` | Set `true` to prevent the skill from invoking other models |
+| `disable-model-invocation` | `false` | Controls whether other models/skills may auto-invoke this skill via discovery/matching. Set `true` to keep the skill strictly user-triggered (the user must type `/<skill-name>` themselves). Does NOT prevent the skill from launching subagents via the `Agent` tool. Rarely needed — only `enhance` uses this in the current collection. |
 | `takes-arg` | `false` | Set `true` if the skill accepts an argument from the user |
 
 ### SKILL.md Body
@@ -68,8 +68,10 @@ See `skills/enhance/README.md` as the reference implementation.
 ## Quality Standards
 
 - **Minimal permissions**: Only request the tools the skill actually needs in `allowed-tools`
-- **Clear description**: The `description` field should be understandable without reading the full prompt
+- **Clear description**: The `description` field should be understandable without reading the full prompt; verb-first phrasing preferred ("Scans...", "Audits...", "Performs...")
+- **Simplicity bias**: Default to a single linear workflow. Only fan out to subagents when there are three genuinely orthogonal analysis lenses (see `skills/create-skill/SKILL.md` R4 — Subagent Decision Gate). `github-ship` is the canonical example of a subagent-free skill.
 - **Safety-conscious**: Skills that launch subagents should use read-only agent types (e.g., Explore) during analysis phases
+- **Plan-mode discipline**: If a skill enters plan mode, `ExitPlanMode` must be called BEFORE any Edit/Write operation — file modifications are blocked while plan mode is active
 - **Self-contained**: Each skill directory should contain everything needed; avoid cross-skill dependencies
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A curated collection of custom skills for [Claude Code](https://docs.anthropic.c
 
 | Skill | Description | Model | Effort |
 |-------|-------------|-------|--------|
-| [enhance](skills/enhance/) | Deep multi-phase project analysis that identifies and recommends the single most impactful addition to implement | Opus | Max |
+| [enhance](skills/enhance/) | Performs deep multi-phase project analysis to identify and recommend the single most impactful addition to implement | Opus | Max |
 | [github-audit](skills/github-audit/) | Audits a GitHub repository against best practices and provides prioritized recommendations | Opus | Max |
 | [code-review](skills/code-review/) | Structured code review with prioritized findings and fix offers | Opus | Max |
 | [test-gen](skills/test-gen/) | Comprehensive test generation with deep code analysis, convention detection, and edge case coverage | Opus | Max |

--- a/lint.sh
+++ b/lint.sh
@@ -72,6 +72,12 @@ lint_skill() {
         fail "Missing required field: description"
     else
         pass "Has 'description' field"
+        # Description should end with a period
+        if [[ "$desc_val" == *"." ]]; then
+            pass "description ends with a period"
+        else
+            warn "description does not end with a period"
+        fi
     fi
 
     local tools_val
@@ -80,6 +86,41 @@ lint_skill() {
         fail "Missing required field: allowed-tools"
     else
         pass "Has 'allowed-tools' field"
+    fi
+
+    # Check plan-mode discipline: if EnterPlanMode is present, ExitPlanMode must be too
+    if [[ "$tools_val" == *"EnterPlanMode"* ]]; then
+        if [[ "$tools_val" == *"ExitPlanMode"* ]]; then
+            pass "EnterPlanMode and ExitPlanMode are paired in allowed-tools"
+        else
+            fail "EnterPlanMode declared without ExitPlanMode in allowed-tools"
+        fi
+    fi
+
+    # Check that the body calls both EnterPlanMode and ExitPlanMode if either is in tools
+    if [[ "$tools_val" == *"EnterPlanMode"* ]]; then
+        if grep -q "EnterPlanMode" "$skill_md"; then
+            pass "body references EnterPlanMode"
+        else
+            fail "EnterPlanMode in allowed-tools but never referenced in body"
+        fi
+        if grep -q "ExitPlanMode" "$skill_md"; then
+            pass "body references ExitPlanMode"
+        else
+            fail "ExitPlanMode in allowed-tools but never referenced in body"
+        fi
+    fi
+
+    # If multi-agent (Agent in tools and body launches subagents), require the IMPORTANT block
+    if [[ "$tools_val" == *"Agent"* ]]; then
+        if grep -qE 'subagent_type:[[:space:]]*"?Explore"?' "$skill_md"; then
+            # Body uses Explore subagents — must include the canonical IMPORTANT block
+            if grep -q 'subagents MUST be launched with' "$skill_md"; then
+                pass "IMPORTANT subagent block present"
+            else
+                warn "Agent + Explore subagents used but canonical IMPORTANT block missing"
+            fi
+        fi
     fi
 
     # Check README.md exists
@@ -104,6 +145,66 @@ lint_skill() {
         pass "README has section: Safety"
     else
         warn "README has no Safety section (optional)"
+    fi
+
+    # README first line description should match SKILL.md description
+    # (skip the "# Title" heading — line 3 is the description in the README template)
+    local readme_desc
+    readme_desc="$(sed -n '3p' "$readme_md")"
+    if [[ -n "$desc_val" && -n "$readme_desc" ]]; then
+        if [[ "$readme_desc" == "$desc_val" ]]; then
+            pass "README description matches SKILL.md description"
+        else
+            warn "README line 3 description differs from SKILL.md description"
+        fi
+    fi
+
+    # Usage section examples should invoke /<name>, not /<some-other-name>.
+    # Only inspect lines that START with /<token> (after optional leading
+    # whitespace and an optional '> ' prompt prefix) — that's how skill
+    # invocations are written in the Usage code blocks. This avoids
+    # false-positives on path components like `/src/auth/`.
+    local bad_invocations
+    bad_invocations="$(awk '/^## Usage/{flag=1; next} /^## /{flag=0} flag' "$readme_md" \
+        | sed -nE 's|^[[:space:]]*>?[[:space:]]*(/[a-z][a-z0-9-]+).*$|\1|p' \
+        | sort -u \
+        | grep -v "^/$name_val$" \
+        || true)"
+    if [[ -n "$bad_invocations" ]]; then
+        warn "README Usage references non-self slash commands: $(echo "$bad_invocations" | tr '\n' ' ')"
+    else
+        pass "README Usage examples reference /$name_val correctly"
+    fi
+
+    # Configuration table should include Takes argument and Allowed tools rows
+    if grep -qE '\|[[:space:]]*Takes argument[[:space:]]*\|' "$readme_md"; then
+        pass "Configuration table has 'Takes argument' row"
+    else
+        warn "Configuration table missing 'Takes argument' row"
+    fi
+    if grep -qE '\|[[:space:]]*Allowed tools[[:space:]]*\|' "$readme_md"; then
+        pass "Configuration table has 'Allowed tools' row"
+    else
+        fail "Configuration table missing 'Allowed tools' row"
+    fi
+
+    # allowed-tools in SKILL.md frontmatter == Allowed tools row in README Configuration table
+    if [[ -n "$tools_val" ]]; then
+        local readme_tools
+        readme_tools="$(grep -E '\|[[:space:]]*Allowed tools[[:space:]]*\|' "$readme_md" \
+            | head -1 \
+            | sed -E 's/^\|[[:space:]]*Allowed tools[[:space:]]*\|[[:space:]]*//' \
+            | sed -E 's/[[:space:]]*\|[[:space:]]*$//' \
+            | tr -d '`')"
+        # Normalize whitespace and trailing spaces
+        local norm_skill_tools norm_readme_tools
+        norm_skill_tools="$(echo "$tools_val" | tr -d '[:space:]')"
+        norm_readme_tools="$(echo "$readme_tools" | tr -d '[:space:]')"
+        if [[ "$norm_skill_tools" == "$norm_readme_tools" ]]; then
+            pass "Allowed tools row matches SKILL.md allowed-tools"
+        else
+            warn "Allowed tools row in README does not match SKILL.md allowed-tools frontmatter"
+        fi
     fi
 }
 

--- a/skills/code-review/README.md
+++ b/skills/code-review/README.md
@@ -33,7 +33,7 @@ Analyzes code changes across multiple quality dimensions using parallel AI agent
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes |
-| Allowed tools | Read, Grep, Glob, Bash, Agent |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -83,6 +83,8 @@ Provide each agent with:
 - The list of changed files
 - Any project convention context gathered in Step 1
 
+**IMPORTANT:** All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"` (resolves to Claude Opus 4.7, the most capable model). The Explore agent is read-only by design (Edit and Write are denied at the agent level). This ensures no subagent can accidentally modify the project during analysis. The model override to Opus is required because Explore defaults to Haiku, which lacks the depth needed for this skill's thorough analysis. Never use general-purpose subagents in this skill.
+
 **IMPORTANT:** Instruct each agent to read the **full files** being changed (not just the diff hunks) so they understand the surrounding context, module purpose, and how the changes integrate with existing code.
 
 Each agent must return findings in this structured format:

--- a/skills/create-skill/README.md
+++ b/skills/create-skill/README.md
@@ -33,7 +33,7 @@ The SKILL.md itself contains a comprehensive **Skill Creation Reference** that d
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: description of the skill to create) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -34,7 +34,7 @@ Every `SKILL.md` must begin with YAML frontmatter between `---` delimiters.
 | Field | Rule |
 |-------|------|
 | `name` | Must match the directory name exactly (e.g., `my-skill` for `skills/my-skill/`) |
-| `description` | One-line summary of what the skill does, ending with a period |
+| `description` | One-line summary, **verb-first** ("Scans...", "Audits...", "Performs..."), ending with a period. Treat this as the marketing copy — it's what shows up in `/help` and the root README. |
 | `allowed-tools` | Comma-separated list of tools the skill may use |
 
 **Standard fields** (used by every existing skill):
@@ -49,7 +49,7 @@ Every `SKILL.md` must begin with YAML frontmatter between `---` delimiters.
 | Field | Default | When to use |
 |-------|---------|-------------|
 | `takes-arg` | `false` | Set `true` if the skill accepts a user argument |
-| `disable-model-invocation` | `false` | Set `true` to prevent invoking other models (rare — only `enhance` uses this) |
+| `disable-model-invocation` | `false` | Controls whether other models/skills may auto-invoke this skill via discovery/matching. Set `true` to keep the skill strictly user-triggered (the user must type `/<skill-name>` themselves). This does NOT prevent the skill from launching subagents via the `Agent` tool. Rarely needed — only `enhance` uses this in the current collection, to avoid being matched as a generic "improve the project" trigger. |
 
 ---
 
@@ -57,25 +57,36 @@ Every `SKILL.md` must begin with YAML frontmatter between `---` delimiters.
 
 Follow the **minimal permissions principle** — only request tools the skill actually needs.
 
-**Base set (every skill includes these):**
+**Base set (every skill that uses plan mode includes these):**
 ```
-Read, Grep, Glob, Bash, Agent, EnterPlanMode, ExitPlanMode
+Read, Grep, Glob, Bash, EnterPlanMode, ExitPlanMode
 ```
+
+Add `Agent` only if the skill genuinely fans out to subagents (see R4 — default is NO subagents).
 
 **Add based on capability:**
 
 | Capability needed | Add these tools |
 |-------------------|----------------|
+| Launch parallel analysis subagents | `Agent` (only if R4's decision gate passes) |
 | Modify existing files | `Edit` |
 | Create new files | `Write` |
 | Internet access (web search, API lookups) | `WebSearch, WebFetch` |
 | Ask the user questions during execution | `AskUserQuestion` |
+| Track progress through a long multi-step execution phase | `TaskCreate, TaskUpdate` (optionally `TaskList`) |
+| Stream output from a long-running background process | `Monitor` (paired with `Bash` using `run_in_background`) |
+| Hand off to or invoke another installed skill | `Skill` |
+| Schedule recurring or one-off future runs | `CronCreate, CronList, CronDelete` (or `ScheduleWakeup` for in-conversation waits) |
+| Read symbol references / definitions via the language server | `LSP` |
 
 **Decision tree:**
 - Does the skill only analyze/report? → Base set only (+ `AskUserQuestion` if it needs to clarify scope)
 - Does the skill modify existing files after analysis? → Add `Edit`
 - Does the skill create new files? → Add `Write`
 - Does the skill need to look up external information? → Add `WebSearch, WebFetch`
+- Does the execution phase loop through many independent units of work (multiple PRs, file edits, update groups)? → Add `TaskCreate, TaskUpdate` for live progress visibility
+- Does the skill spawn long-running shell commands (slow test suites, deploys) where polling output makes sense? → Pair `Bash` (`run_in_background: true`) with `Monitor`
+- Does the skill naturally chain into another `/skill` for follow-up work? → Add `Skill`
 
 ---
 
@@ -117,11 +128,19 @@ Not every skill needs all 4 steps. Analysis-only skills may have 3 steps. Skills
 
 ---
 
-### R4: Subagents
+### R4: Subagents (optional — default NO)
 
-Skills that perform multi-dimensional analysis launch **exactly 3 Explore subagents in parallel**.
+**Default to NO subagents.** Many useful skills work as a single linear workflow without delegating to parallel investigators. `github-ship` is the strongest example of this pattern in the collection — it's a deterministic state-detect → present-plan → execute flow with no agent fan-out, and it's all the better for it.
 
-**Configuration (mandatory):**
+**Decision gate.** Before adding subagents, ask out loud:
+
+> *"What three orthogonal dimensions does this skill analyze?"*
+
+If you can't name three independent lenses that genuinely benefit from parallel investigation, **do not add subagents** — put the work directly in the skill body. Three near-duplicate "agents" that all read the same files and produce overlapping findings is the failure mode the simplicity bias exists to prevent.
+
+If the answer is yes — three genuinely orthogonal lenses (e.g., `code-review`'s correctness / security / performance / conventions split, or `refactor`'s correctness-security / performance / structure split) — then proceed with the rest of this rule.
+
+**Configuration (mandatory when using subagents):**
 ```
 subagent_type: "Explore"
 model: "opus"
@@ -293,11 +312,13 @@ When combining findings from multiple agents, the synthesis step must follow the
 
 Every skill's `README.md` must contain these sections **in this order**:
 
-1. **Title** — `# <Skill Name>` followed by a one-line description
-2. **What It Does** — describe the workflow and phases
+1. **Title** — `# <Skill Name>` followed by a one-line description that matches the SKILL.md `description` field verbatim.
+2. **What It Does** — describe the workflow and phases. The intro sentence uses the canonical wording:
+   - For step-numbered skills: *"…, delivered in N steps:"*
+   - For phase-numbered skills: *"Runs a strategic N-phase analysis…"* or *"Runs an N-phase audit…"*
 3. **Requirements** — model access, dependencies, prerequisites
-4. **Usage** — how to invoke (e.g., `/<skill-name>` or `/<skill-name> <argument>`)
-5. **Configuration** — table of frontmatter settings (Model, Effort, Takes argument, Allowed tools)
+4. **Usage** — how to invoke (e.g., `/<skill-name>` or `/<skill-name> <argument>`). Examples MUST use the skill's actual name in the slash command.
+5. **Configuration** — table of frontmatter settings. Required rows: `Model`, `Effort`, `Takes argument`, `Allowed tools`. The `Allowed tools` row must list the SAME tools as the SKILL.md `allowed-tools` frontmatter (including `EnterPlanMode`/`ExitPlanMode` if they're there).
 6. **Safety** — bullet points with bold labels describing what the skill can and cannot do
 
 The **Safety** section uses this pattern:
@@ -349,30 +370,37 @@ After creating a new skill, these project files must also be updated:
 
 ## Step 1: Gather Requirements
 
-If no argument was provided, ask the user what skill they want to create using `AskUserQuestion`.
+If an argument was provided, parse it as a description of the desired skill's purpose. Otherwise, ask the user what skill they want to create (an inline plain-text question is fine here — the answer is freeform).
 
-If an argument was provided, parse it as a description of the desired skill's purpose.
-
-Then ask the user the following questions (skip any that are already answered by the argument):
-
-1. **Name** — What should the skill be called? Suggest a name following the existing pattern (lowercase, hyphenated, concise). The name must be unique among existing skills.
-
-2. **Argument** — Does the skill accept a user argument? If so, what kinds of input? (file path, directory, identifier, description, etc.)
-
-3. **Capability** — Does the skill:
-   - Only analyze and report? (read-only)
-   - Modify existing files? (needs Edit)
-   - Create new files? (needs Write)
-   - Need internet access? (needs WebSearch, WebFetch)
-
-4. **Workflow** — What is the core workflow? What are the analysis dimensions? Skills typically analyze through 2-3 complementary lenses — what are the right lenses for this skill?
-
-5. **Output** — What does the final report look like? What finding ID prefix should be used?
-
-Read the existing skills directory to check for name conflicts:
+Read the existing skills directory to check for name conflicts before suggesting one:
 ```bash
 ls skills/
 ```
+
+Then collect the structured requirements. **Issue a single `AskUserQuestion` call** with up to 4 batched questions (skip any that are already answered by the argument):
+
+1. **Argument behavior** — single-select, options:
+   - `No argument` (skill always runs the same way)
+   - `Optional argument` (auto-detect when missing)
+   - `Required argument` (skill stops if missing)
+
+2. **Capabilities needed** — multi-select, options:
+   - `Modify existing files` (adds `Edit`)
+   - `Create new files` (adds `Write`)
+   - `Internet access` (adds `WebSearch, WebFetch`)
+   - `Track multi-step progress` (adds `TaskCreate, TaskUpdate`)
+   - `Hand off to another skill` (adds `Skill`)
+   - `Background commands + streaming output` (adds `Monitor`)
+
+3. **Subagent fan-out** — single-select (per R4's decision gate), options:
+   - `No subagents — single linear flow` (default; mirrors `github-ship`)
+   - `3 Explore subagents — three orthogonal analysis lenses` (mirrors `code-review`, `refactor`)
+
+For the freeform requirements that don't fit multiple-choice (skill name, workflow design, output format, finding-ID letter), follow up with plain-text questions or batch them into a second `AskUserQuestion` call if structured options are appropriate. Specifically still gather:
+
+- **Name** — suggest a name following the existing pattern (lowercase, hyphenated, concise). The name must be unique among existing skills.
+- **Workflow** — what is the core workflow? If subagents were selected, what are the three orthogonal lenses?
+- **Output** — what does the final report look like? What finding ID prefix should be used (per R5)?
 
 State the gathered requirements clearly before proceeding.
 
@@ -388,7 +416,7 @@ Based on the requirements from Step 1, design the complete skill. Read 1-2 exist
 
 2. **Argument resolution** — which steps from the R9 cascade are relevant? Design the resolution logic.
 
-3. **Agent structure** — define the 3 analysis agents per R4:
+3. **Subagent structure** — apply R4's decision gate first. **If the skill does not have three orthogonal analysis lenses, skip subagents entirely** and design a single linear workflow. Only if the decision gate passes (yes, three independent dimensions), design the 3 analysis agents:
    - What dimension does each agent cover?
    - What specific checklist items does each agent evaluate?
    - What structured format does each agent return?

--- a/skills/dep-check/README.md
+++ b/skills/dep-check/README.md
@@ -33,7 +33,7 @@ Performs a comprehensive dependency audit across every ecosystem present in the 
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: file path, directory, or ecosystem name) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/dep-check/SKILL.md
+++ b/skills/dep-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dep-check
 description: Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations.
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -90,6 +90,8 @@ Provide each agent with the complete list of discovered manifest files, their fu
 ### Agent 1: Application Dependencies — Package Manager Updates
 
 For each package manager ecosystem detected, check every dependency for available updates.
+
+**IMPORTANT — issue commands in parallel.** When checking multiple ecosystems, the per-ecosystem `outdated`/`audit`/`list` commands are independent and should be issued as **parallel `Bash` tool calls in a single response** (one tool-call block, multiple `Bash` entries). Sequential execution serializes 8+ commands that each take 10-60 seconds and inflates wall-clock time without improving accuracy. Wrap each command with `timeout 60 ...` so a slow/hanging tool doesn't block the rest of the sweep, and record which invocations timed out vs which were unavailable vs which returned empty results.
 
 **Use CLI tools when available (preferred — faster and more accurate):**
 
@@ -403,46 +405,35 @@ If applicable: To check these, install `<tool>` and re-run, or run: `<manual com
 5. **Major updates** — ordered by migration effort (easiest first)
 6. **CI/CD and infrastructure** — Actions, Docker, Terraform versions
 
+After the report is presented, call `ExitPlanMode`.
+
 ---
 
 ## Step 4: Offer to Apply Updates
 
-After presenting the report, if there are any updates available, ask:
+If there are any updates available, ask:
 
 > **Want me to apply any of these updates?** (e.g., "apply all", "apply group 1", "apply security patches only", "apply V1 and V3")
 
-If the user requests updates:
+If the user requests updates, apply them by **editing the manifest files in place** — do not run any install/network commands. The user runs install/test themselves after reviewing the diff.
+
+**Track progress with tasks.** Before applying the first update, call `TaskCreate` once per approved update group so the user sees live progress through Step 4. Each task's subject should be the group title (e.g., `Group 1: Security patches`). Mark a task `in_progress` when you begin the group's edits and `completed` once all manifests in that group have been edited.
 
 1. Apply updates group by group in the order specified.
-2. For package manager updates, use the appropriate CLI command:
-   ```bash
-   # npm
-   npm install <package>@<version>
-
-   # Python (requirements.txt) — edit the version pin directly
-   # Python (pyproject.toml / Pipfile) — edit the version constraint
-
-   # Rust
-   cargo update -p <package>
-
-   # Go
-   go get <module>@<version>
-
-   # Ruby
-   bundle update <gem>
-
-   # PHP
-   composer require <package>:<version>
-   ```
-3. For CI/CD and infrastructure updates, use the Edit tool to modify version pins in the relevant files.
+2. For each manifest, use the `Edit` tool to bump the version constraint to the target version. Examples (the literal text in your `old_string`/`new_string` will match each ecosystem's manifest syntax):
+   - **npm/yarn/pnpm** — bump the version in `package.json` `dependencies` / `devDependencies`.
+   - **Python `requirements.txt`** — replace `<package>==<old>` with `<package>==<new>`.
+   - **Python `pyproject.toml` / `Pipfile`** — bump the version constraint.
+   - **Rust** — bump the version in `Cargo.toml` `[dependencies]`. (A subsequent `cargo update -p "<package>"` is something the user runs to refresh `Cargo.lock`.)
+   - **Go** — bump the version in `go.mod` `require`. (User runs `go get "<module>@<version>"` afterward to refresh `go.sum`.)
+   - **Ruby** — bump the version in `Gemfile`. (User runs `bundle update "<gem>"` to refresh `Gemfile.lock`.)
+   - **PHP** — bump the version in `composer.json` `require`. (User runs `composer update "<package>"` to refresh `composer.lock`.)
+   - **.NET** — bump the version in the `.csproj` `<PackageReference Version="..." />`.
+3. For CI/CD and infrastructure updates (GitHub Actions `uses:`, Docker `FROM`, Terraform `version`, pre-commit `rev:`), use `Edit` to modify the version pin in the relevant file.
 4. After applying each group, show a summary of what changed:
-   > **Applied Group 1**: Updated 3 packages in `package.json`. Run `<test command>` to verify.
-5. Do NOT run install commands (`npm install`, `pip install`, etc.) or test commands automatically — only update the version declarations in the manifest files. Tell the user what commands to run:
-   > I've updated the version declarations. Run `<install command>` to install the new versions, then `<test command>` to verify.
+   > **Applied Group 1**: Updated 3 packages in `package.json`. Run `<install command>` then `<test command>` to verify.
+5. Do **not** run install commands (`npm install`, `pip install`, `cargo update`, `bundle install`, etc.) or test commands automatically. Once you've finished editing manifests, tell the user what to run. Always quote `<package>` and `<version>` arguments in the commands you suggest, since version constraints can contain shell metacharacters like `<`, `>`, and spaces:
+   > I've updated the version declarations. Run `npm install` (or `cargo update -p "<package>"`, `bundle update "<gem>"`, `composer update "<package>"`, etc. — quote the package/version) to refresh lockfiles and install the new versions, then `<test command>` to verify.
 
 If the report shows zero updates and zero vulnerabilities, skip the update offer:
 > All dependencies are up to date and no known vulnerabilities were found.
-
----
-
-Once the report is presented (and any requested updates are applied), call `ExitPlanMode`.

--- a/skills/diagnose/README.md
+++ b/skills/diagnose/README.md
@@ -4,7 +4,7 @@ Multi-agent root cause analysis that traces errors, correlates with recent chang
 
 ## What It Does
 
-Performs structured debugging through parallel investigation, delivered in 3 steps:
+Performs structured root cause analysis through parallel investigation, delivered in 3 steps:
 
 1. **Problem Parsing** -- classifies the input (stack trace, error message, file path, or natural language description) and identifies the error type, affected files, and language/framework context. If no argument is provided, auto-detects recent test or CI failures.
 2. **Parallel Investigation** -- launches 3 parallel agents: Error Trace Analysis (follows the call chain backward to find where behavior diverges from intent), Change Correlation (checks recent git history for commits that could have introduced the bug), and Pattern & Context Analysis (searches for similar issues in the codebase and known issues online)
@@ -19,10 +19,10 @@ Performs structured debugging through parallel investigation, delivered in 3 ste
 ## Usage
 
 ```
-/debug TypeError: Cannot read properties of undefined (reading 'map')
-/debug "the login page redirects to 404 after submitting"
-/debug src/auth/handler.ts
-/debug                                    # Auto-detect: check recent test/CI failures
+/diagnose TypeError: Cannot read properties of undefined (reading 'map')
+/diagnose "the login page redirects to 404 after submitting"
+/diagnose src/auth/handler.ts
+/diagnose                                 # Auto-detect: check recent test/CI failures
 ```
 
 ## Configuration
@@ -32,7 +32,7 @@ Performs structured debugging through parallel investigation, delivered in 3 ste
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: error message, stack trace, file path, or description) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -56,13 +56,10 @@ Determine what to investigate based on the argument and project state.
    ```
    If tests fail, use the failure output as the error to investigate.
 
-2. **Recent CI failures** — check for failed GitHub Actions runs:
+2. **Recent CI failures** — check for failed GitHub Actions runs. Capture the run id from JSON output and pass it to `gh run view`:
    ```bash
-   gh run list --status failure --limit 1 --json databaseId,displayTitle,conclusion,headBranch 2>/dev/null
-   ```
-   If a recent failure exists, fetch the failed job logs:
-   ```bash
-   gh run view <id> --log-failed 2>/dev/null | tail -100
+   run_id=$(gh run list --status failure --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null)
+   [ -n "$run_id" ] && gh run view "$run_id" --log-failed 2>/dev/null | tail -100
    ```
 
 3. **Uncommitted changes with issues** — check if there are unstaged changes that might contain the problem:
@@ -135,24 +132,25 @@ Investigate whether recent code changes introduced or exposed the bug.
   ```bash
   git log --oneline -20 2>/dev/null
   ```
-- Get recent changes to the files involved in the error:
+- Get recent changes to the files involved in the error. For each file path extracted from the error in Step 1, run:
   ```bash
-  git log --oneline -10 -- <error_file_1> <error_file_2> 2>/dev/null
+  git log --oneline -10 -- "<path>" 2>/dev/null
   ```
-- Get the full diff of the most recent commits touching the error files:
+- Get the full diff of the most recent commit touching each error file:
   ```bash
-  git log -1 --format=%H -- <error_files> 2>/dev/null
-  git show <commit_hash> 2>/dev/null
+  commit_hash=$(git log -1 --format=%H -- "<path>" 2>/dev/null)
+  [ -n "$commit_hash" ] && git show "$commit_hash" 2>/dev/null
   ```
-- If on a feature branch, diff against the default branch:
+- If on a feature branch, diff each error file against the default branch:
   ```bash
   default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
   [ -z "$default_branch" ] && git rev-parse --verify main >/dev/null 2>&1 && default_branch=main
   [ -z "$default_branch" ] && git rev-parse --verify master >/dev/null 2>&1 && default_branch=master
   ```
   ```bash
-  git diff "$default_branch"...HEAD -- <error_files> 2>/dev/null
+  git diff "$default_branch"...HEAD -- "<path>" 2>/dev/null
   ```
+  (Repeat the per-file `git log` / `git diff` commands for every path Step 1 extracted from the error.)
 - Read the full diff of any suspect commits and assess:
   - Did a recent change modify the failing code path?
   - Did a recent change modify a dependency of the failing code (a function it calls, a config it reads)?
@@ -175,13 +173,13 @@ Search for broader context: similar patterns, known issues, and environmental fa
   - Same error type occurring elsewhere (might reveal a known workaround or correct pattern)
   - Same API or function used correctly elsewhere (might reveal what the failing code is doing differently)
   - Same data type or structure handled differently in other modules
-- Search for markers near the error site:
+- Search for markers near the error site. For each file path extracted in Step 1:
   ```bash
-  grep -n "TODO\|FIXME\|HACK\|XXX\|WORKAROUND\|BUG" <error_files> 2>/dev/null
+  grep -n "TODO\|FIXME\|HACK\|XXX\|WORKAROUND\|BUG" "<path>" 2>/dev/null
   ```
-- Check project issues for similar problems:
+- Check project issues for similar problems. Extract 2-4 short keywords from the error message (function names, distinctive nouns) and pass them as a quoted search string:
   ```bash
-  gh issue list --state all --search "<error_keywords>" --limit 5 2>/dev/null
+  gh issue list --state all --search "<keywords>" --limit 5 2>/dev/null
   ```
 - If the error involves a third-party library or API, search for known issues:
   - Use WebSearch: `"<library_name>" "<error_message>" site:github.com OR site:stackoverflow.com`

--- a/skills/docstring-check/README.md
+++ b/skills/docstring-check/README.md
@@ -38,7 +38,7 @@ The key behaviors are **convention-matching** (fixes adopt the project's detecte
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: file path, directory, symbol name, branch, commit range, or description) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/docstring-check/SKILL.md
+++ b/skills/docstring-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docstring-check
 description: Scans a codebase for missing, outdated, drifted, or inconsistent docstrings and applies behavior-preserving fixes matching the project's detected convention.
-allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -364,11 +364,20 @@ After presenting the plan, call `ExitPlanMode`, then ask:
 
 After the user approves (or modifies) the plan, apply the changes.
 
-**Before making any changes**, create a backup if the working tree has modifications or the repo tracks these files:
+**Before making any changes**, capture a backup stash that you can identify reliably later. `git stash push` exits 0 even when there's nothing to stash, so use `git stash create` + `git stash store` to capture an explicit SHA instead:
+
 ```bash
-git stash push -m "docstring-check-backup: before /docstring-check changes" 2>/dev/null
+backup_sha=$(git stash create "docstring-check-backup: before /docstring-check changes" 2>/dev/null)
+if [ -n "$backup_sha" ]; then
+  git stash store -m "docstring-check-backup: before /docstring-check changes" "$backup_sha"
+fi
 ```
-If the stash succeeds (exit code 0 and output is not "No local changes to save"), note that a backup was created. If the repository has uncommitted changes outside the docstring fix scope, warn the user before proceeding.
+
+If `$backup_sha` is non-empty, a backup exists at that SHA — record it so a later "revert all" can use `git stash apply "$backup_sha"` to restore exactly that snapshot. If `$backup_sha` is empty, the working tree was clean — proceed without a backup.
+
+If the repository has uncommitted changes outside the docstring fix scope, warn the user before proceeding.
+
+**Track progress with tasks.** Before applying the first fix, call `TaskCreate` once per file touched by the selected findings (one task per file, batching the findings within that file into the task description). Mark `in_progress` when you begin editing the file and `completed` once all its findings are applied. For large plans (20+ files) this gives the user a real-time view of how many files are left and which one is currently being edited.
 
 **Execution rules:**
 
@@ -417,7 +426,7 @@ If the stash succeeds (exit code 0 and output is not "No local changes to save")
    >
    > Options:
    > - "revert D4" — undo just that change
-   > - "revert all" — restore to pre-fix state (`git stash pop`)
+   > - "revert all" — restore to pre-fix state (`git stash apply "$backup_sha"` against the SHA captured before Step 4)
    > - "fix it" — attempt to correct the proposed docstring while preserving the fix intent
 
 9. **If no verification tool is available**, instruct the user:

--- a/skills/enhance/README.md
+++ b/skills/enhance/README.md
@@ -1,16 +1,17 @@
 # Enhance
 
-Deep multi-phase project analysis that identifies and recommends the single most impactful addition to implement.
+Performs deep multi-phase project analysis to identify and recommend the single most impactful addition to implement.
 
 ## What It Does
 
-Runs a strategic 5-phase analysis of your project, then converges on one compelling, concrete recommendation:
+Runs a strategic 6-phase analysis of your project, then converges on one compelling, concrete recommendation:
 
 1. **Deep Project Reconnaissance** -- scans structure, stack, git history, test coverage, and quality gaps
 2. **Project Type Classification** -- categorizes the project (library, CLI, web app, API service, etc.)
 3. **Domain & Context Understanding** -- identifies purpose, target users, maturity stage, and strengths
 4. **Gap & Opportunity Analysis** -- type-specific analysis of what's missing or underexploited
 5. **Innovation Synthesis** -- scores candidates on innovation, feasibility, impact, and delight; picks one winner
+6. **The Recommendation** -- presents the chosen addition with an implementation sketch, then exits plan mode and offers to implement
 
 The skill asks clarifying questions throughout the analysis to tailor its recommendation to your actual priorities and constraints.
 
@@ -38,8 +39,9 @@ The skill automatically:
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
+| Takes argument | No |
 | Disable model invocation | `true` |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, LSP, EnterPlanMode, ExitPlanMode, AskUserQuestion |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, EnterPlanMode, ExitPlanMode, AskUserQuestion |
 
 ## Safety
 

--- a/skills/enhance/SKILL.md
+++ b/skills/enhance/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: enhance
-description: Deep multi-phase project analysis that identifies and recommends the single most impactful addition to implement. Runs in plan mode for analysis, then exits for implementation.
+description: Performs deep multi-phase project analysis to identify and recommend the single most impactful addition to implement.
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, LSP, EnterPlanMode, ExitPlanMode, AskUserQuestion
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, EnterPlanMode, ExitPlanMode, AskUserQuestion
 model: opus
 effort: max
 ---
 
-**Step 1: Enter Plan Mode immediately using the EnterPlanMode tool before doing anything else.**
+Call `EnterPlanMode` immediately before doing anything else.
 
 You are about to perform a deep, multi-phase analysis of the current project to identify and recommend THE single most impactful, innovative addition you can make. This is not a code review or a list of improvements — it's a strategic deep-dive that culminates in one compelling, concrete recommendation.
 
@@ -15,7 +15,7 @@ Execute each phase thoroughly before moving to the next. Use subagents for paral
 
 **Ask the user questions at any point during the analysis when it would improve the result.** Don't make assumptions about priorities, pain points, or goals when you can ask. Examples: after Phase 1, ask what areas matter most to them; during Phase 3, confirm which problems they actually feel; before Phase 4, ask if there are constraints or preferences you should know about. The goal is a recommendation tailored to what the user needs right now, not a generic suggestion.
 
-**IMPORTANT: All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"`.** The Explore agent is read-only by design (Edit and Write are denied at the agent level). This ensures no subagent can accidentally modify the project during analysis. The model override is required because Explore defaults to Haiku, which is too shallow for this skill's deep analysis. Never use general-purpose subagents in this skill.
+**IMPORTANT:** All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"` (resolves to Claude Opus 4.7, the most capable model). The Explore agent is read-only by design (Edit and Write are denied at the agent level). This ensures no subagent can accidentally modify the project during analysis. The model override to Opus is required because Explore defaults to Haiku, which lacks the depth needed for this skill's thorough analysis. Never use general-purpose subagents in this skill.
 
 ---
 
@@ -65,7 +65,7 @@ Compile your findings into a mental model of the project before proceeding.
 
 ---
 
-## Phase 1.5: Project Type Classification
+## Phase 2: Project Type Classification
 
 Based on Phase 1 findings, classify the project as one of:
 - **Library/Package** — consumed by other developers as a dependency
@@ -75,11 +75,11 @@ Based on Phase 1 findings, classify the project as one of:
 - **Infrastructure/DevOps** — IaC, CI/CD tooling, platform config
 - **Other** — describe it
 
-State the classification clearly before proceeding. This classification shapes the analysis in Phase 3.
+State the classification clearly before proceeding. This classification shapes the analysis in Phase 4.
 
 ---
 
-## Phase 2: Domain & Context Understanding
+## Phase 3: Domain & Context Understanding
 
 Based on Phase 1, synthesize a deeper understanding:
 
@@ -94,7 +94,7 @@ Summarize this understanding briefly before moving on.
 
 ---
 
-## Phase 3: Gap & Opportunity Analysis
+## Phase 4: Gap & Opportunity Analysis
 
 Now think critically about what's missing or underexploited:
 
@@ -106,7 +106,7 @@ Now think critically about what's missing or underexploited:
 - What's the **weakest link** in the project's value chain?
 - What's the **biggest risk** the project currently faces (technical debt, scalability, security, DX)?
 
-**Additionally, ask these type-specific questions based on the Phase 1.5 classification:**
+**Additionally, ask these type-specific questions based on the Phase 2 classification:**
 
 - **Library/Package** — API ergonomics? Documentation and examples quality? Bundle size / tree-shaking? Backwards compatibility strategy? Publishing pipeline?
 - **CLI Tool** — UX and help text quality? Shell completions? Config file support? Error messages and exit codes? Interactive vs non-interactive mode?
@@ -118,7 +118,7 @@ Generate a broad list of potential improvements and opportunities. Don't filter 
 
 ---
 
-## Phase 4: Innovation Synthesis
+## Phase 5: Innovation Synthesis
 
 Now converge. This is the creative, strategic phase:
 
@@ -137,7 +137,7 @@ Score each candidate idea on four axes:
 
 ---
 
-## Phase 5: The Recommendation
+## Phase 6: The Recommendation
 
 Present your recommendation in this format:
 
@@ -170,6 +170,6 @@ Briefly mention 2-3 runner-up ideas and why this one wins.
 
 ---
 
-**Step 2: After presenting the full recommendation, exit Plan Mode using the ExitPlanMode tool**, then ask: **"Want me to implement this now?"**
+After presenting the full recommendation, call `ExitPlanMode`, then ask: **"Want me to implement this now?"**
 
 This way the user can immediately proceed with implementation in the same session.

--- a/skills/github-audit/README.md
+++ b/skills/github-audit/README.md
@@ -1,6 +1,6 @@
 # GitHub Audit
 
-Audits a GitHub repository against best practices and provides prioritized recommendations for improving README quality, licensing, community health, CI/CD, repository settings, and documentation.
+Audits a GitHub repository against best practices and provides prioritized recommendations for README, license, community health, CI/CD, and repository settings.
 
 ## What It Does
 
@@ -30,7 +30,8 @@ The skill enters plan mode automatically, performs the audit using read-only Exp
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, AskUserQuestion, EnterPlanMode, ExitPlanMode |
+| Takes argument | No |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/github-audit/SKILL.md
+++ b/skills/github-audit/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: github-audit
 description: Audits a GitHub repository against best practices and provides prioritized recommendations for README, license, community health, CI/CD, and repository settings.
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, AskUserQuestion, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 ---
 
-**Step 1: Enter Plan Mode immediately using the EnterPlanMode tool before doing anything else.**
+Call `EnterPlanMode` immediately before doing anything else.
 
 You are about to perform a comprehensive audit of this GitHub repository against GitHub best practices. Your goal is to identify what's missing, what's incomplete, and what can be improved — then present a prioritized, actionable list of recommendations.
 
@@ -14,7 +14,7 @@ Execute each phase thoroughly before moving to the next. Use subagents for paral
 
 **Ask the user questions when it would improve the result.** For example: after Phase 1, ask about the project's intended audience (public library vs internal tool vs personal project) since this affects which best practices matter most.
 
-**IMPORTANT: All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"`.** The Explore agent is read-only by design. Never use general-purpose subagents in this skill.
+**IMPORTANT:** All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"` (resolves to Claude Opus 4.7, the most capable model). The Explore agent is read-only by design (Edit and Write are denied at the agent level). This ensures no subagent can accidentally modify the project during analysis. The model override to Opus is required because Explore defaults to Haiku, which lacks the depth needed for this skill's thorough analysis. Never use general-purpose subagents in this skill.
 
 ---
 
@@ -22,7 +22,7 @@ Execute each phase thoroughly before moving to the next. Use subagents for paral
 
 Launch Explore agents in parallel to gather data on all GitHub-relevant aspects of the repository.
 
-**Agent 1: File & Structure Audit**
+### Agent 1: File & Structure Audit
 
 Scan for the presence, location, and quality of these files:
 
@@ -45,7 +45,7 @@ Scan for the presence, location, and quality of these files:
 
 Read each file that exists. Note which are missing entirely.
 
-**Agent 2: README Deep Analysis**
+### Agent 2: README Deep Analysis
 
 If a README exists, evaluate it against these criteria:
 
@@ -61,7 +61,7 @@ If a README exists, evaluate it against these criteria:
 - **Links to documentation** — If there are docs, are they linked?
 - **Contact / support** — How to get help or report issues?
 
-**Agent 3: GitHub Settings & CI/CD**
+### Agent 3: GitHub Settings & CI/CD
 
 Use bash commands to check:
 
@@ -87,26 +87,30 @@ git log --oneline -20 2>/dev/null
 cat .gitignore 2>/dev/null
 ```
 
-If the repo has a GitHub remote, use `gh` CLI to check:
+If the repo has a GitHub remote, use `gh` CLI to check. First resolve the repo slug and default branch so the API paths can be substituted explicitly (`gh api` does not auto-expand `{owner}/{repo}` placeholders):
 
 ```bash
-# Repository metadata
+# Repository metadata (also yields the slug and default branch)
 gh repo view --json name,description,url,homepageUrl,isPrivate,hasIssuesEnabled,hasWikiEnabled,hasDiscussionsEnabled,hasProjectsEnabled,licenseInfo,repositoryTopics,defaultBranchRef,stargazerCount,forkCount 2>/dev/null
 
-# Check if GitHub Pages is enabled
-gh api repos/{owner}/{repo}/pages 2>/dev/null
+# Resolve slug and default branch for the subsequent API calls
+slug=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)
+default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name 2>/dev/null)
 
-# Check branch protection rules
-gh api repos/{owner}/{repo}/branches/main/protection 2>/dev/null || gh api repos/{owner}/{repo}/branches/master/protection 2>/dev/null
+# Check if GitHub Pages is enabled
+[ -n "$slug" ] && gh api "repos/$slug/pages" 2>/dev/null
+
+# Check branch protection rules on the actual default branch (not a guess of main/master)
+[ -n "$slug" ] && [ -n "$default_branch" ] && gh api "repos/$slug/branches/$default_branch/protection" 2>/dev/null
 
 # Check if Dependabot alerts are enabled
-gh api repos/{owner}/{repo}/vulnerability-alerts 2>/dev/null
+[ -n "$slug" ] && gh api "repos/$slug/vulnerability-alerts" 2>/dev/null
 
 # Check releases
 gh release list --limit 5 2>/dev/null
 
 # Check secrets scanning
-gh api repos/{owner}/{repo}/secret-scanning/alerts --paginate 2>/dev/null | head -5
+[ -n "$slug" ] && gh api "repos/$slug/secret-scanning/alerts" --paginate 2>/dev/null | head -5
 ```
 
 Note: many of these commands may fail on private repos or repos without certain features enabled. That's fine — a failed check is itself a finding.
@@ -207,4 +211,11 @@ Specific, actionable steps. Include example content, commands, or file templates
 
 Aim for 5-10 concrete recommendations. Focus on what would have the most impact for this specific project — not a generic checklist. Consider the project's type, audience, and maturity stage when prioritizing.
 
-**Step 2: After presenting the full audit, exit Plan Mode using the ExitPlanMode tool**, then ask: **"Want me to implement any of these recommendations?"**
+**Skill handoff.** If a recommendation maps cleanly to another installed skill in this collection, suggest invoking it via the `Skill` tool instead of implementing manually. Examples:
+- "Dependencies are stale / no Dependabot configured" → suggest `/dep-check`
+- "No tests" or "test coverage gaps" → suggest `/test-gen`
+- "Missing docstrings on public API" → suggest `/docstring-check`
+- "Code smells / refactoring opportunities surfaced by the audit" → suggest `/refactor`
+- "Ready to ship a fix and you don't have a PR workflow set up" → suggest `/github-ship`
+
+After presenting the full audit, call `ExitPlanMode`, then ask: **"Want me to implement any of these recommendations?"**

--- a/skills/github-ship/SKILL.md
+++ b/skills/github-ship/SKILL.md
@@ -135,18 +135,17 @@ After approval, execute in order. If any step fails, stop and report.
    issue_number=$(echo "$issue_url" | grep -oE '[0-9]+$')
    ```
 
-5. Create the PR:
+5. Create the PR. Build the body with `Closes #$issue_number` interpolated into the first line, but use a quoted heredoc (`<<'EOF'`) for the rest so that any `$`, backtick, or `$(...)` sequences inside the bullets or checklist are treated as literal text (no shell substitution):
    ```bash
-   gh pr create --base "$default_branch" --title "<pr title>" --body "$(cat <<EOF
-   Closes #$issue_number
-
+   pr_body=$(printf 'Closes #%s\n\n' "$issue_number"; cat <<'EOF'
    ## Summary
    <bullets>
 
    ## Test plan
    <checklist>
    EOF
-   )"
+   )
+   printf '%s\n' "$pr_body" | gh pr create --base "$default_branch" --title "<pr title>" --body-file -
    ```
 
 6. Report:
@@ -194,21 +193,32 @@ After approval:
 ```bash
 git checkout "$default_branch"
 git pull --ff-only
-git branch -d "$current_branch" 2>&1
 ```
 
-If `git branch -d` refuses with "not fully merged" (normal for squash-merged or rebase-merged PRs), ask inline:
+Try the safe local delete. Capture the exit code — do NOT proceed to remote delete unless local delete succeeded or the user explicitly approves the force-delete:
+
+```bash
+if git branch -d "$current_branch" 2>&1; then
+  local_deleted=yes
+else
+  local_deleted=no
+fi
+```
+
+If `local_deleted=no` (normal for squash-merged or rebase-merged PRs), ask inline:
 
 > Local branch has commits not on `<default>`. This is normal for squash/rebase merges. Force-delete? (yes/no)
 
-If yes:
+If the user answers yes:
 ```bash
-git branch -D "$current_branch"
+git branch -D "$current_branch" && local_deleted=yes
 ```
 
-Then delete the remote branch if it still exists:
+If the user answers no, stop here — do NOT delete the remote branch. The user can rerun the skill after sorting the branch out, or delete it manually.
+
+Only after `local_deleted=yes`, delete the remote branch if it still exists:
 ```bash
-if git ls-remote --heads origin "$current_branch" | grep -q .; then
+if [ "$local_deleted" = "yes" ] && git ls-remote --heads origin "$current_branch" | grep -q .; then
   git push origin --delete "$current_branch"
 fi
 ```

--- a/skills/idiom-check/README.md
+++ b/skills/idiom-check/README.md
@@ -6,7 +6,7 @@ Audits a codebase through a programming-language-specific idiom lens, produces a
 
 Where `/code-review` reviews a diff and `/refactor` works against a single target, `/idiom-check` audits the **whole codebase** through a **language-specific** idiom lens. The output is calibrated to the language: a Rust codebase is reviewed for ownership and trait design; a Python codebase for Pythonic constructs and modern type hints; a Go codebase for error-wrapping and channel idioms — and so on.
 
-The skill runs in 5 steps:
+The skill is delivered in 5 steps:
 
 1. **Detect Language and Resolve Scope** — Inspects manifests (`Cargo.toml`, `go.mod`, `pyproject.toml`, `package.json`, `Gemfile`, …), counts source files per language to pick the dominant one, gathers project conventions (`CLAUDE.md`, `.editorconfig`, language-specific lint configs), and narrows the scope when the codebase is large.
 2. **Multi-Lens Language-Specific Analysis** — Launches 3 parallel read-only Opus 4.7 agents, each looking through one of three orthogonal language-specific lenses (e.g. for Rust: Ownership / Type-System / Idioms-&-Control-Flow). Each agent reads the full files in scope, caps findings at ~12, and frames every finding as "why in THIS codebase".
@@ -38,7 +38,7 @@ The skill takes no argument. It always audits the whole repository (with optiona
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | No |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/idiom-check/SKILL.md
+++ b/skills/idiom-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idiom-check
 description: Audits a codebase through a programming-language-specific idiom lens, produces a prioritized report, and offers remediation in PR-sized bundles.
-allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 ---
@@ -310,6 +310,8 @@ default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@
 [ -z "$default_branch" ] && git rev-parse --verify main >/dev/null 2>&1 && default_branch=main
 [ -z "$default_branch" ] && git rev-parse --verify master >/dev/null 2>&1 && default_branch=master
 ```
+
+**Track progress with tasks.** Before processing the first bundle, call `TaskCreate` once per approved bundle so the user sees live progress through the ship phase. Each task's subject should be the bundle title (`[B1] <title>`). As you start a bundle, mark its task `in_progress`; after the PR is opened, mark it `completed`. If a bundle's commit or push fails, leave the task `in_progress` and report the failure inline.
 
 **Per-bundle workflow** — repeat for each approved bundle:
 

--- a/skills/refactor/README.md
+++ b/skills/refactor/README.md
@@ -37,7 +37,7 @@ The key innovation is **cross-cutting synthesis**: changes that improve multiple
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: file path, directory, function name, branch, commit range, or description) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refactor
 description: Comprehensive code refactoring across correctness, security, performance, and maintainability with behavior-preserving, incremental changes.
-allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -330,11 +330,20 @@ After presenting the refactoring plan, call `ExitPlanMode`, then ask:
 
 After the user approves (or modifies) the plan, apply the changes.
 
-**Before making any changes**, if a test runner was detected in Step 1, create a backup:
+**Before making any changes**, capture a backup stash that you can identify reliably later. `git stash push` exits 0 even when there's nothing to stash, so use `git stash create` + `git stash store` to capture an explicit SHA instead:
+
 ```bash
-git stash push -m "refactor-backup: before /refactor changes" 2>/dev/null
+backup_sha=$(git stash create "refactor-backup: before /refactor changes" 2>/dev/null)
+if [ -n "$backup_sha" ]; then
+  git stash store -m "refactor-backup: before /refactor changes" "$backup_sha"
+fi
 ```
-If the stash succeeds (exit code 0 and output is not "No local changes to save"), note that a backup was created. If the repository has uncommitted changes outside the refactoring scope, warn the user before proceeding.
+
+If `$backup_sha` is non-empty, a backup exists at that SHA — record it so a later "revert all" can use `git stash apply "$backup_sha"` (or `git checkout "$backup_sha" -- .`) to restore exactly that snapshot rather than popping whatever stash happens to be on top. If `$backup_sha` is empty, the working tree was clean — proceed without a backup.
+
+If the repository has uncommitted changes outside the refactoring scope, warn the user before proceeding.
+
+**Track progress with tasks.** Before applying the first change, call `TaskCreate` once per selected refactoring (one task per `[R<n>]` finding). The subject should be the finding ID + title (e.g., `[R3] Extract input validation`). Mark `in_progress` when you start the Edit for that finding and `completed` after it's applied. Refactoring plans regularly have 10-30 findings; this keeps the user oriented through the execution phase.
 
 **Execution rules:**
 
@@ -362,7 +371,7 @@ If the stash succeeds (exit code 0 and output is not "No local changes to save")
    >
    > Options:
    > - "revert R4" — undo just that change
-   > - "revert all" — restore to pre-refactoring state (`git stash pop`)
+   > - "revert all" — restore to pre-refactoring state (`git stash apply "$backup_sha"` against the SHA captured before Step 4)
    > - "fix it" — attempt to fix the failing test while preserving the refactoring intent
 
 8. **If no test runner is available:**

--- a/skills/test-gen/README.md
+++ b/skills/test-gen/README.md
@@ -34,7 +34,7 @@ Generates high-quality tests through deep code analysis and convention detection
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/test-gen/SKILL.md
+++ b/skills/test-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-gen
 description: Analyzes code to generate comprehensive tests covering happy paths, edge cases, error handling, and integration points, matching the project's existing test conventions.
-allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -90,6 +90,8 @@ Launch **3 Explore subagents in parallel** (`subagent_type: "Explore"`, `model: 
 Provide each agent with:
 - The resolved target files from Step 1
 - The project context (manifest, test config, conventions)
+
+**IMPORTANT:** All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"` (resolves to Claude Opus 4.7, the most capable model). The Explore agent is read-only by design (Edit and Write are denied at the agent level). This ensures no subagent can accidentally modify the project during analysis. The model override to Opus is required because Explore defaults to Haiku, which lacks the depth needed for this skill's thorough analysis. Never use general-purpose subagents in this skill.
 
 **IMPORTANT:** Instruct each agent to read the **full target files** (not just snippets) so they understand the complete code structure, all branches, and how functions relate to each other.
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,13 +1,18 @@
 # Skill Name
 
-One-line description of what the skill does.
+One-line description (must match the SKILL.md `description` field verbatim).
 
 ## What It Does
 
-Describe the skill's workflow. If it has multiple phases, list them:
+Describe the skill's workflow. Standard intro wording:
 
-1. **Phase 1** -- what happens first
-2. **Phase 2** -- what happens next
+- For step-numbered skills: *"…, delivered in N steps:"*
+- For phase-numbered skills: *"Runs a strategic N-phase analysis…"*
+
+Then list the steps/phases:
+
+1. **Step 1** -- what happens first
+2. **Step 2** -- what happens next
 
 ## Requirements
 
@@ -32,10 +37,17 @@ Or if the skill takes an argument:
 |---------|-------|
 | Model | `default` |
 | Effort | `default` |
-| Allowed tools | `Read, Grep, Glob` |
+| Takes argument | No |
+| Allowed tools | `Read, Grep, Glob, Bash, EnterPlanMode, ExitPlanMode` |
+
+The `Allowed tools` row must list the SAME tools as the SKILL.md `allowed-tools` frontmatter.
 
 ## Safety
 
 <!-- Remove this section if not applicable -->
 
-Describe what the skill can and cannot modify. Note any read-only guarantees or safety mechanisms.
+Describe what the skill can and cannot modify. Note any read-only guarantees or safety mechanisms. Common bullets:
+
+- **Read-only analysis**: …
+- **User approval gate**: …
+- **No commits or pushes**: …

--- a/templates/SKILL.md
+++ b/templates/SKILL.md
@@ -1,20 +1,33 @@
 ---
 name: SKILL_NAME
-description: One-line summary of what the skill does
-allowed-tools: Read, Grep, Glob
+description: Verb-first one-line summary of what the skill does, ending with a period.
+allowed-tools: Read, Grep, Glob, Bash, EnterPlanMode, ExitPlanMode
 # model: opus                        # Optional: opus, sonnet, haiku
 # effort: max                        # Optional: min, low, medium, high, max
-# disable-model-invocation: true     # Optional: prevent invoking other models
+# disable-model-invocation: true     # Optional: keep skill strictly user-triggered (does NOT block subagents)
 # takes-arg: true                    # Optional: accept an argument from the user
 ---
 
-<!-- Replace this comment block with the skill's prompt. -->
-<!--                                                      -->
-<!-- Guidelines:                                          -->
-<!-- - Use clear step numbering for multi-phase workflows -->
-<!-- - Use --- separators between major phases            -->
-<!-- - State subagent requirements explicitly              -->
-<!-- - If using plan mode: start with EnterPlanMode,      -->
-<!--   end with ExitPlanMode                              -->
+<!-- Skill prompt body. Replace this comment with content. -->
+<!--                                                       -->
+<!-- Canonical structure:                                  -->
+<!-- 1. First line: `Call \`EnterPlanMode\` immediately   -->
+<!--    before doing anything else.`                       -->
+<!-- 2. 1-3 sentence mission statement                     -->
+<!-- 3. If takes-arg: ARGUMENTS line + quoting note        -->
+<!-- 4. `---` separator                                    -->
+<!-- 5. Numbered steps (`## Step N: <Title>`) separated   -->
+<!--    by `---` rules                                     -->
+<!-- 6. The LAST step ends with: present report → call    -->
+<!--    `ExitPlanMode` → action offer question →         -->
+<!--    execute changes (Edit/Write happen here, AFTER    -->
+<!--    plan mode exit)                                    -->
+<!--                                                       -->
+<!-- Subagents: default NO. Only add `Agent` to            -->
+<!-- allowed-tools and fan out to 3 Explore agents if the  -->
+<!-- skill has THREE genuinely orthogonal analysis lenses. -->
+<!-- See `skills/create-skill/SKILL.md` R4 decision gate.  -->
 
-Your skill prompt goes here. Describe what Claude should do when this skill is invoked.
+Call `EnterPlanMode` immediately before doing anything else.
+
+Your mission statement goes here. Describe what Claude should do when this skill is invoked.


### PR DESCRIPTION
Closes #53

## Summary

- **Bundle A — Critical fixes**: `dep-check` `ExitPlanMode` placement moved before the action offer (was unreachable while plan mode was still active); `diagnose` README slash-command corrected from `/debug` to `/diagnose`; `github-audit` `gh api repos/{owner}/{repo}/...` placeholders now resolved via `gh repo view`; `github-ship` PR-body heredoc switched to `<<'EOF'` (shell-substitution injection risk) and branch cleanup now gates the remote delete on local-delete success; `diagnose` `<id>` / `<error_file_N>` shell placeholders replaced with explicit `jq` extraction and per-path loops; `refactor` and `docstring-check` use `git stash create` + `git stash store` so the backup is captured by SHA (avoids accidental `stash pop` of an unrelated stash); `dep-check` reconciled the "edit manifests vs run install" contradiction and quotes version/package arguments.
- **Bundle B — Consistency**: canonical `` Call `EnterPlanMode` immediately before doing anything else. `` opening lines restored in `enhance` and `github-audit`; the full canonical IMPORTANT subagent block (Explore + Opus + safety reasoning) restored everywhere it was missing (`enhance`, `github-audit`, `test-gen`, `code-review`); `### Agent N:` headings in `github-audit`; `Takes argument | No` rows added to `enhance`/`github-audit` README Configuration tables; every README's `Allowed tools` row now matches the SKILL.md frontmatter exactly; `enhance` phases renumbered 1-6 (was 1, 1.5, 2-5) and the README phase list aligned; `enhance` description shortened to one sentence and aligned across SKILL.md / README / root README; `LSP` removed from `enhance`'s `allowed-tools` (was unused); `idiom-check` README "delivered in N steps" wording aligned.
- **Bundle C — Meta-skill overhaul (`create-skill`)**: R4 (Subagents) now defaults to NO subagents and adds a Decision Gate ("can you name three orthogonal lenses?") so future single-job skills don't get force-fit into the 3-agent pipeline — directly addresses the simplicity bias documented in the user's feedback memory. R2 (Tool Selection) documents modern primitives (`TaskCreate`/`TaskUpdate`, `Monitor`, `Skill`, `CronCreate`, `LSP`) and when to add each. Step 1 batches the structured requirements into an explicit `AskUserQuestion` call. R1 description rule mandates verb-first phrasing ending with a period. R11 codifies "delivered in N steps" wording and verbatim-match between SKILL.md description and README first line. `CLAUDE.md` clarifies `disable-model-invocation` semantics (controls auto-invocation, does NOT block subagents) and adds Simplicity Bias and Plan-Mode Discipline to Quality Standards. Templates (`templates/SKILL.md`, `templates/README.md`) regenerated to reflect canonical opening line and default tool set (no `Agent` by default).
- **Bundle D — Modern features adopted**: `TaskCreate`/`TaskUpdate` wired into the four looping skills (`idiom-check` Step 5 ships bundles, `dep-check` Step 4 applies update groups, `docstring-check` Step 4 applies fixes file-by-file, `refactor` Step 4 applies refactorings finding-by-finding) so the user sees live progress through multi-unit execution. `github-audit` gains `Skill` tool handoff guidance for recommendations that map cleanly to other installed skills (`/dep-check`, `/test-gen`, `/docstring-check`, `/refactor`, `/github-ship`). `dep-check` Step 2 now mandates parallel `Bash` tool calls for the per-ecosystem `outdated`/`audit`/`list` sweep with `timeout 60` per command and explicit timeout/unavailable/empty tracking.
- **Bundle E — Lint expansion**: `lint.sh` gained 6+ regression-prevention checks — description ends with a period; matched `EnterPlanMode`/`ExitPlanMode` pairs in frontmatter and body references; canonical IMPORTANT subagent block presence when `Agent` is used with Explore subagents; README line 3 matches SKILL.md description; Usage examples invoke the correct `/<name>`; Configuration table has `Takes argument` and `Allowed tools` rows; allowed-tools parity between SKILL.md frontmatter and README Configuration table.

## Test plan

- [ ] `./lint.sh` passes (241 checks, 0 warnings, 0 failures)
- [ ] Spot-check `skills/dep-check/SKILL.md`: Step 3 ends with `Call ExitPlanMode.`, Step 4 edits manifests via `Edit` then tells the user what install commands to run (with quoting)
- [ ] Spot-check `skills/diagnose/README.md`: every Usage example uses `/diagnose`; line 7 says "structured root cause analysis"
- [ ] Spot-check `skills/github-ship/SKILL.md`: PR body uses `<<'EOF'`; cleanup gates `git push origin --delete` on `local_deleted=yes`
- [ ] Spot-check `skills/github-audit/SKILL.md`: `gh api` calls use `"repos/$slug/..."` not literal `repos/{owner}/{repo}/...`
- [ ] Spot-check `skills/create-skill/SKILL.md` R4: Decision Gate text present; "Default to NO subagents" leading line
- [ ] Spot-check `skills/enhance/SKILL.md`: phases are 1, 2, 3, 4, 5, 6 (no 1.5); description is one sentence; `LSP` not in frontmatter
- [ ] Spot-check `lint.sh` new checks by manually breaking one rule in a copy and confirming it flags
