### PR TITLE
Modernize output (printf, tput) + bash 3.2+ version floor

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,20 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Require bash 3.2+ (macOS system /bin/bash is 3.2; Homebrew bash and Ubuntu CI
+# are 5+). Fails loud on `sh`-as-bash or ancient bash setups so we don't get
+# the "works on CI, silently broken on macOS" class of bug.
+if (( BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2) )); then
+    printf 'Error: bash 3.2+ required (found %s)\n' "$BASH_VERSION" >&2
+    exit 1
+fi
+
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$REPO_DIR/skills"
 TARGET_DIR="$HOME/.claude/skills"
 
-# Colors (disabled if not a terminal)
-if [[ -t 1 ]]; then
-    GREEN='\033[0;32m'
-    YELLOW='\033[0;33m'
-    RED='\033[0;31m'
-    BOLD='\033[1m'
-    NC='\033[0m'
+# Colors (disabled if not a terminal or terminal has no color support).
+# Use `tput` so the right escape sequence is picked for the actual terminfo
+# entry (xterm, screen, dumb, etc.) instead of hardcoding xterm-only bytes.
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
+    GREEN="$(tput setaf 2)"
+    YELLOW="$(tput setaf 3)"
+    RED="$(tput setaf 1)"
+    BOLD="$(tput bold)"
+    NC="$(tput sgr0)"
 else
     GREEN='' YELLOW='' RED='' BOLD='' NC=''
 fi
+
+# Emit a colored tagged line. Mirrors the pass/fail/warn helpers in lint.sh.
+emit() {  # emit COLOR TAG MSG
+    printf '  %s[%s]%s %s\n' "$1" "$2" "$NC" "$3"
+}
 
 install_skill() {
     local skill_name="$1"
@@ -22,7 +37,7 @@ install_skill() {
     local target="$TARGET_DIR/$skill_name"
 
     if [[ ! -d "$source" ]]; then
-        echo -e "  ${RED}[error]${NC} Skill '$skill_name' not found in $SKILLS_DIR"
+        emit "$RED" "error" "Skill '$skill_name' not found in $SKILLS_DIR"
         return 1
     fi
 
@@ -32,41 +47,43 @@ install_skill() {
         local existing_link
         existing_link="$(readlink "$target")"
         if [[ "$existing_link" == "$source" ]]; then
-            echo -e "  ${GREEN}[skip]${NC} $skill_name -- already linked correctly"
+            emit "$GREEN" "skip" "$skill_name -- already linked correctly"
             return 0
         fi
-        echo -e "  ${YELLOW}[update]${NC} $skill_name -- replacing existing symlink (was: $existing_link)"
+        emit "$YELLOW" "update" "$skill_name -- replacing existing symlink (was: $existing_link)"
         rm "$target"
     elif [[ -d "$target" ]]; then
-        echo -e "  ${YELLOW}[backup]${NC} $skill_name -- existing directory backed up to ${target}.bak"
+        emit "$YELLOW" "backup" "$skill_name -- existing directory backed up to ${target}.bak"
         mv "$target" "${target}.bak"
     elif [[ -e "$target" ]]; then
-        echo -e "  ${YELLOW}[backup]${NC} $skill_name -- existing file backed up to ${target}.bak"
+        emit "$YELLOW" "backup" "$skill_name -- existing file backed up to ${target}.bak"
         mv "$target" "${target}.bak"
     fi
 
     ln -s "$source" "$target"
-    echo -e "  ${GREEN}[installed]${NC} $skill_name -> $source"
+    emit "$GREEN" "installed" "$skill_name -> $source"
 }
 
-echo -e "${BOLD}Claude Code Skills Installer${NC}"
-echo "============================"
-echo ""
+printf '%sClaude Code Skills Installer%s\n' "$BOLD" "$NC"
+printf '============================\n\n'
 
 if [[ $# -gt 0 ]]; then
     for skill in "$@"; do
         install_skill "$skill"
     done
 else
-    echo "Installing all skills from $SKILLS_DIR:"
-    echo ""
+    printf 'Installing all skills from %s:\n\n' "$SKILLS_DIR"
+    # `shopt -s nullglob` so the loop body doesn't run on the literal pattern
+    # when the directory is empty (otherwise `set -u` + a literal `$SKILLS_DIR/*/`
+    # would still pass `-d`, but be safer than sorry).
+    shopt -s nullglob
     for skill_dir in "$SKILLS_DIR"/*/; do
-        [[ -d "$skill_dir" ]] || continue
-        skill_name="$(basename "$skill_dir")"
+        skill_name="${skill_dir%/}"
+        skill_name="${skill_name##*/}"
         install_skill "$skill_name"
     done
+    shopt -u nullglob
 fi
 
-echo ""
-echo "Done. Skills are symlinked from ~/.claude/skills/ to this repository."
-echo "Run 'git pull' in this repo to update skills."
+printf '\nDone. Skills are symlinked from ~/.claude/skills/ to this repository.\n'
+printf "Run 'git pull' in this repo to update skills.\n"

--- a/lint.sh
+++ b/lint.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Require bash 3.2+ (macOS system /bin/bash is 3.2; Homebrew bash and Ubuntu CI
+# are 5+). Fails loud on `sh`-as-bash or ancient bash setups so we don't get
+# the "works on CI, silently broken on macOS" class of bug.
+if (( BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2) )); then
+    printf 'Error: bash 3.2+ required (found %s)\n' "$BASH_VERSION" >&2
+    exit 1
+fi
+
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$REPO_DIR/skills"
 
-# Colors (disabled if not a terminal)
-if [[ -t 1 ]]; then
-    GREEN='\033[0;32m'
-    YELLOW='\033[0;33m'
-    RED='\033[0;31m'
-    BOLD='\033[1m'
-    NC='\033[0m'
+# Colors (disabled if not a terminal or terminal has no color support).
+# Use `tput` so the right escape sequence is picked for the actual terminfo
+# entry instead of hardcoding xterm-only bytes.
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
+    GREEN="$(tput setaf 2)"
+    YELLOW="$(tput setaf 3)"
+    RED="$(tput setaf 1)"
+    BOLD="$(tput bold)"
+    NC="$(tput sgr0)"
 else
     GREEN='' YELLOW='' RED='' BOLD='' NC=''
 fi
@@ -19,9 +29,12 @@ TOTAL_PASS=0
 TOTAL_FAIL=0
 TOTAL_WARN=0
 
-pass() { echo -e "  ${GREEN}[pass]${NC} $1"; TOTAL_PASS=$((TOTAL_PASS + 1)); }
-fail() { echo -e "  ${RED}[fail]${NC} $1"; TOTAL_FAIL=$((TOTAL_FAIL + 1)); }
-warn() { echo -e "  ${YELLOW}[warn]${NC} $1"; TOTAL_WARN=$((TOTAL_WARN + 1)); }
+# Use `printf` instead of `echo -e` so behavior is identical across bash
+# builtin / dash / BSD echo. The color variables already hold literal escape
+# bytes thanks to `tput` above (no `\033` literals to interpret).
+pass() { printf '  %s[pass]%s %s\n' "$GREEN"  "$NC" "$1"; TOTAL_PASS=$((TOTAL_PASS + 1)); }
+fail() { printf '  %s[fail]%s %s\n' "$RED"    "$NC" "$1"; TOTAL_FAIL=$((TOTAL_FAIL + 1)); }
+warn() { printf '  %s[warn]%s %s\n' "$YELLOW" "$NC" "$1"; TOTAL_WARN=$((TOTAL_WARN + 1)); }
 
 # Extract a frontmatter field value from a SKILL.md file
 get_frontmatter() {
@@ -35,7 +48,7 @@ lint_skill() {
     local skill_md="$skill_dir/SKILL.md"
     local readme_md="$skill_dir/README.md"
 
-    echo -e "\n${BOLD}Checking: $skill_name${NC}"
+    printf '\n%sChecking: %s%s\n' "$BOLD" "$skill_name" "$NC"
 
     # Check SKILL.md exists
     if [[ ! -f "$skill_md" ]]; then
@@ -208,39 +221,41 @@ lint_skill() {
     fi
 }
 
-echo -e "${BOLD}Claude Skills Linter${NC}"
-echo "===================="
+printf '%sClaude Skills Linter%s\n' "$BOLD" "$NC"
+printf '====================\n'
 
 if [[ $# -gt 0 ]]; then
     for skill in "$@"; do
         if [[ ! -d "$SKILLS_DIR/$skill" ]]; then
-            echo -e "\n${RED}Error: Skill '$skill' not found in $SKILLS_DIR${NC}"
+            printf '\n%sError: Skill %s not found in %s%s\n' "$RED" "'$skill'" "$SKILLS_DIR" "$NC"
             TOTAL_FAIL=$((TOTAL_FAIL + 1))
             continue
         fi
         lint_skill "$skill"
     done
 else
+    # `shopt -s nullglob` so the loop body doesn't run on the literal pattern
+    # when the directory is empty. Trailing `/` in the glob already restricts
+    # to directories, so the in-loop `-d` test is redundant.
+    shopt -s nullglob
     for skill_dir in "$SKILLS_DIR"/*/; do
-        [[ -d "$skill_dir" ]] || continue
-        skill_name="$(basename "$skill_dir")"
+        skill_name="${skill_dir%/}"
+        skill_name="${skill_name##*/}"
         lint_skill "$skill_name"
     done
+    shopt -u nullglob
 fi
 
-echo ""
-echo -e "${BOLD}Summary${NC}"
-echo "-------"
-echo -e "  ${GREEN}Passed: $TOTAL_PASS${NC}"
-[[ $TOTAL_WARN -gt 0 ]] && echo -e "  ${YELLOW}Warnings: $TOTAL_WARN${NC}"
-[[ $TOTAL_FAIL -gt 0 ]] && echo -e "  ${RED}Failed: $TOTAL_FAIL${NC}"
+printf '\n%sSummary%s\n' "$BOLD" "$NC"
+printf -- '-------\n'
+printf '  %sPassed: %s%s\n' "$GREEN" "$TOTAL_PASS" "$NC"
+[[ $TOTAL_WARN -gt 0 ]] && printf '  %sWarnings: %s%s\n' "$YELLOW" "$TOTAL_WARN" "$NC"
+[[ $TOTAL_FAIL -gt 0 ]] && printf '  %sFailed: %s%s\n' "$RED" "$TOTAL_FAIL" "$NC"
 
 if [[ $TOTAL_FAIL -gt 0 ]]; then
-    echo ""
-    echo -e "${RED}Lint failed with $TOTAL_FAIL error(s).${NC}"
+    printf '\n%sLint failed with %s error(s).%s\n' "$RED" "$TOTAL_FAIL" "$NC"
     exit 1
 else
-    echo ""
-    echo -e "${GREEN}All checks passed.${NC}"
+    printf '\n%sAll checks passed.%s\n' "$GREEN" "$NC"
     exit 0
 fi


### PR DESCRIPTION
## Summary

Six cross-cutting modernizations discovered by `/idiom-check`, applied to both `lint.sh` and `install.sh`.

- **[I7]** Replace every `echo -e` with `printf`. `echo -e` is non-POSIX and behavior differs between bash builtin, dash, and BSD echo. Pairs well with [I17] since the color variables now hold literal escape bytes (no `\033` escapes left to interpret).
- **[I8]** Add an explicit `bash 3.2+` version floor at the top of each script. macOS system `/bin/bash` is 3.2 (Apple frozen); Homebrew and Ubuntu CI are 5+. The guard turns "works on CI, mysteriously broken on Mac" into a clean error before anything else runs.
- **[I10]** Extract an `emit COLOR TAG MSG` helper in `install.sh`, mirroring the `pass`/`fail`/`warn` helpers in `lint.sh`. Single place to change the format if we ever want JSON output, a `--quiet` flag, etc.
- **[I16]** Replace `basename "$skill_dir"` with bash parameter expansion `${skill_dir%/}` + `${...##*/}`. Eliminates the per-skill `basename` subprocess.
- **[I17]** Replace hardcoded `\033[...]` ANSI escapes with `tput setaf` / `tput bold` / `tput sgr0`. tput consults terminfo, so it does the right thing on screen/tmux/dumb terminals and respects the terminal's actual color count.
- **[I19]** Add `shopt -s nullglob` around the `for skill_dir in ".../*/"` loops. Drop the now-redundant `[[ -d "$skill_dir" ]] || continue` inside the loop body (the trailing `/` already restricts to directories).

## Test plan

- [ ] `bash -n lint.sh && bash -n install.sh` passes
- [ ] `./lint.sh` produces identical pass/warn output (241 checks)
- [ ] Run `./lint.sh` in a non-TTY context (e.g., piped to `cat`) — verify color escapes are suppressed
- [ ] Run with `TERM=dumb ./lint.sh` — should produce uncolored output without errors
- [ ] Run `bash --version` < 3.2 (if you have one) — should error cleanly with the version-floor message

## Note on merge order

This PR touches both `install.sh` and `lint.sh` and will conflict with PR #55 (install.sh data-loss prevention) and PRs #56/#57 (lint.sh pipeline hardening / bash builtins). Conflicts are mechanical — keep B4's `printf`/`tput`/`emit` style and re-apply B1/B2/B3's behavioral changes on top.
