### PR TITLE
Add Bash function comment headers (docstring-check audit)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,16 +26,30 @@ else
     GREEN='' YELLOW='' RED='' BOLD='' NC=''
 fi
 
-# Emit a colored tagged line. Mirrors the pass/fail/warn helpers in lint.sh.
-emit() {  # emit COLOR TAG MSG
+# Emit a colored, two-bracket-tagged status line to stdout.
+#
+# Args: $1 = ANSI color escape (may be empty), $2 = short tag (e.g.
+# "skip", "backup", "installed"), $3 = message. Generic helper inspired
+# by pass/fail/warn in lint.sh but, unlike those, does NOT mutate any
+# totals counter (install.sh has no summary block).
+emit() {
     printf '  %s[%s]%s %s\n' "$1" "$2" "$NC" "$3"
 }
 
-# Crash safety: if a backup was made but the symlink wasn't recreated (e.g. Ctrl-C
-# between the `mv` and `ln`), restore the backup so the user isn't left empty-handed.
+# Crash-safety globals — set by install_skill across the mv→ln window,
+# read by restore_on_exit so a Ctrl-C between the `mv` and the `ln`
+# doesn't leave the user empty-handed.
 PENDING_TARGET=""
 PENDING_BACKUP=""
 
+# EXIT/INT/TERM trap handler — the crash-safety net for install_skill.
+#
+# Reads the PENDING_TARGET / PENDING_BACKUP globals (set by install_skill
+# just before `mv "$target" "$bak"` and cleared after the new `ln -snf`
+# succeeds). If they're non-empty and the new symlink wasn't created
+# (Ctrl-C between the mv and the ln, or the ln itself failed), atomically
+# moves the backup back into place. Calls `exit "$rc"` with the original
+# exit status so the trap is transparent to `set -euo pipefail`.
 restore_on_exit() {
     local rc=$?
     if [[ -n "$PENDING_BACKUP" && -n "$PENDING_TARGET" ]]; then
@@ -47,6 +61,15 @@ restore_on_exit() {
 }
 trap restore_on_exit EXIT INT TERM
 
+# Install a single skill by symlinking it from $SKILLS_DIR into $TARGET_DIR.
+#
+# Idempotent: an already-correct symlink is skipped; a stale symlink is
+# replaced atomically via `ln -snf`; an existing real file/dir is renamed to
+# a `.bak` (timestamp-suffixed if a prior `.bak` already exists). Side
+# effects: sets PENDING_TARGET and PENDING_BACKUP across the mv→ln window
+# so restore_on_exit can roll back if interrupted, then clears them on
+# success. Args: $1 = skill name (a directory under $SKILLS_DIR). Returns
+# 1 if the source dir is missing, 0 otherwise.
 install_skill() {
     local skill_name="$1"
     local source="$SKILLS_DIR/$skill_name"

--- a/lint.sh
+++ b/lint.sh
@@ -29,16 +29,32 @@ TOTAL_PASS=0
 TOTAL_FAIL=0
 TOTAL_WARN=0
 
-# Use `printf` instead of `echo -e` so behavior is identical across bash
-# builtin / dash / BSD echo. The color variables already hold literal escape
-# bytes thanks to `tput` above (no `\033` literals to interpret).
+# Status-line helpers. Each prints an indented, colored, tagged line to
+# stdout and bumps the corresponding TOTAL_* counter that the summary
+# block at the bottom of the file reads. Args: $1 = message text.
+#   pass: bumps TOTAL_PASS (green [pass] tag).
+#   fail: bumps TOTAL_FAIL (red [fail] tag); a non-zero TOTAL_FAIL is
+#         what causes the script to `exit 1` at the bottom.
+#   warn: bumps TOTAL_WARN (yellow [warn] tag); non-blocking.
+#
+# Implementation note: `printf` instead of `echo -e` so behavior is
+# identical across the bash builtin, dash, and BSD echo. The color
+# variables already hold literal escape bytes from `tput` above (no
+# `\033` literals to interpret).
 pass() { printf '  %s[pass]%s %s\n' "$GREEN"  "$NC" "$1"; TOTAL_PASS=$((TOTAL_PASS + 1)); }
 fail() { printf '  %s[fail]%s %s\n' "$RED"    "$NC" "$1"; TOTAL_FAIL=$((TOTAL_FAIL + 1)); }
 warn() { printf '  %s[warn]%s %s\n' "$YELLOW" "$NC" "$1"; TOTAL_WARN=$((TOTAL_WARN + 1)); }
 
 # Extract a frontmatter field value from a SKILL.md file.
-# Pure-bash implementation so genuine file/read errors aren't swallowed by `|| true`
-# the way they were in the old `sed | grep | head | sed || true` pipeline.
+#
+# Args: $1 = SKILL.md path, $2 = frontmatter key. Returns 0 with no output
+# when the key is absent (callers test with `[[ -z "$x" ]]`). Does NOT trim
+# trailing whitespace; callers normalize via parameter expansion as needed
+# (see the `${tools_val//[[:space:]]/}` comparison further down).
+#
+# Pure-bash implementation so genuine file/read errors aren't swallowed by
+# `|| true` the way they were in the old `sed | grep | head | sed || true`
+# pipeline.
 get_frontmatter() {
     local file="$1" field="$2" line in_fm=0
     while IFS= read -r line; do
@@ -55,6 +71,18 @@ get_frontmatter() {
     done < "$file"
 }
 
+# Run every lint check against a single skill directory.
+#
+# Validates the skill's SKILL.md frontmatter (name/dir agreement, description
+# punctuation, allowed-tools, EnterPlanMode/ExitPlanMode pairing in both
+# frontmatter and body, IMPORTANT subagent block when Agent + Explore are
+# used) and README.md (required sections, line-3 description match, Usage
+# slash-command references, Configuration table rows, allowed-tools parity
+# between SKILL.md frontmatter and README). Side effects: bumps the global
+# TOTAL_PASS/TOTAL_FAIL/TOTAL_WARN counters via the pass/fail/warn helpers,
+# and prints a "Checking: <skill>" banner to stdout. Args: $1 = skill name
+# (a directory under $SKILLS_DIR). Uses bare `return` (not `return 1`) for
+# early-exit on missing SKILL.md/README.md so the outer summary still runs.
 lint_skill() {
     local skill_name="$1"
     local skill_dir="$SKILLS_DIR/$skill_name"


### PR DESCRIPTION
## Summary

Six docstring-style improvements to the Bash function headers in `lint.sh` and `install.sh`, discovered by `/docstring-check` (adapted to Bash, since the repo has no source code in any of the skill's 13 supported languages).

**Comment-only changes; no behavior or output differences.** `./lint.sh` still passes 241 checks; `bash -n` clean on both files.

- **[D1]** Add a header to `install_skill()` documenting idempotency, the timestamped-backup behavior (B1), the `PENDING_TARGET`/`PENDING_BACKUP` contract with `restore_on_exit`, args, and return codes.
- **[D2]** Add a header to `lint_skill()` documenting every check it runs, the `TOTAL_*` counter side effects, the "Checking:" banner, and the bare-`return` early-exit semantics.
- **[D3]** Move the crash-safety header from the `PENDING_*` globals (where it visually bannered the wrong identifier) onto `restore_on_exit` itself, with explicit mention of EXIT/INT/TERM trap installation and the `exit "$rc"` preservation contract.
- **[D4]** Replace `emit()`'s mixed block-header + inline `# emit COLOR TAG MSG` style with a single block header documenting args. Notes that `emit` deliberately does NOT mutate counters (install.sh has no summary block), so future maintainers don't add counter logic by analogy with `pass`/`fail`/`warn`.
- **[D5]** Expand the shared `pass`/`fail`/`warn` header to document each helper's `TOTAL_*` side effect and the fact that `TOTAL_FAIL` is what causes the script to `exit 1` — the prior header only explained the `printf`-vs-`echo -e` rationale and omitted the load-bearing contract.
- **[D6]** Tighten `get_frontmatter()`'s header with two small additions: it returns 0/no-output on key-absent, and does NOT trim trailing whitespace (callers do).

## Test plan

- [x] `bash -n lint.sh && bash -n install.sh` passes
- [x] `./lint.sh` passes (241 checks, 0 warnings, 0 failures)
- [x] No code changes — `git diff` shows only comment additions
