### PR TITLE
Harden CI/release workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run skill linter
-        run: chmod +x lint.sh && ./lint.sh
+        run: bash lint.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Validate tag format
+        run: |
+          # Strictly accept v<major>.<minor>.<patch> with optional pre-release suffix.
+          # Rejects typos like "vv1.0.0" before any downstream parsing depends on them.
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Tag $GITHUB_REF_NAME is not a valid semver tag (expected vX.Y.Z[-pre])"
+            exit 1
+          fi
+
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
@@ -28,14 +37,20 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Extract the section for this version from CHANGELOG.md
-          # Matches from "## [X.Y.Z]" until the next "## [" or end of file
+          # Extract the section for this version from CHANGELOG.md.
+          # - Anchor the version match to "^## \[<ver>\]" so substring tags
+          #   (e.g. v1 matching [1.0.0]) can't collide.
+          # - Stop emitting on the next "## [" heading OR the first link-reference
+          #   line ([Unreleased]: ...) so the trailing compare-URL block in
+          #   CHANGELOG.md doesn't leak into the oldest entry's release body.
           notes=$(awk -v ver="$VERSION" '
+            BEGIN { pat = "^## \\[" ver "\\]" }
             /^## \[/ {
               if (found) exit
-              if (index($0, "[" ver "]")) found=1
+              if ($0 ~ pat) found=1
               next
             }
+            /^\[[^]]+\]:[[:space:]]*http/ { if (found) exit }
             found { print }
           ' CHANGELOG.md)
 
@@ -44,18 +59,28 @@ jobs:
             exit 1
           fi
 
-          # Write to output using delimiter syntax
+          # Write to output using a random delimiter so a literal "EOF_..." line
+          # in CHANGELOG can't terminate the value early (GitHub-published
+          # hardening for GITHUB_OUTPUT heredocs).
+          delim="EOF_$(openssl rand -hex 16)"
           {
-            echo "notes<<RELEASE_NOTES_EOF"
+            echo "notes<<$delim"
             echo "$notes"
-            echo "RELEASE_NOTES_EOF"
+            echo "$delim"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES: ${{ steps.notes.outputs.notes }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --notes "$RELEASE_NOTES"
+          # Idempotent: if a release already exists for this tag (re-pushed tag,
+          # workflow retry, etc.), edit its notes instead of erroring out.
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --notes "$RELEASE_NOTES"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes "$RELEASE_NOTES"
+          fi


### PR DESCRIPTION
## Summary

Seven workflow hardening fixes from the `/code-review` audit.

### Fixed (workflow correctness)

- **[W1]** `release.yml` is now idempotent on re-pushed tags. If a release already exists for the tag, the workflow edits it instead of failing with `already_exists`. **This is the exact bug we hit during the v0.1.1 release** that required manual tag deletion + recreation.
- **[W2]** `release.yml` awk extraction stops at the first link-reference line (`^[...]: http...`) so the trailing CHANGELOG compare-URL block no longer leaks into the oldest release's notes.
- **[W3]** `lint.yml` gains an explicit `permissions: contents: read` block. Previously inherited the repository default `GITHUB_TOKEN` scope, which is more than the lint job needs.
- **[W4]** `lint.yml` runs `bash lint.sh` instead of `chmod +x lint.sh && ./lint.sh`. The chmod was silently re-adding the executable bit on every run, masking any real permission regression in git.

### Hardening (defense-in-depth)

- **[S1]** `release.yml` `GITHUB_OUTPUT` heredoc now uses a random delimiter (`EOF_$(openssl rand -hex 16)`) so a literal `RELEASE_NOTES_EOF` line in CHANGELOG can't terminate the value early.
- **[S2]** `release.yml` validates the tag against `^v[0-9]+\.[0-9]+\.[0-9]+(-...)?$` up front, rejecting typos like `vv1.0.0` before any downstream parsing.
- **[S3]** `release.yml` awk uses an anchored regex (`^## \[<ver>\]`) instead of substring search, so future short tags like `v1` can't accidentally match `[1.0.0]`.

### Test plan

- [x] `./lint.sh` passes (241 checks)
- [x] Local awk dry-run against actual CHANGELOG: v0.1.1, v0.0.1, and substring-collision case all behave correctly
- [ ] After merge: cut a `v0.1.2` (or similar) tag to exercise the new workflow path end-to-end
