### PR TITLE
Align spec docs with lint enforcement (post-v0.1.0)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@
 
 - [ ] `./lint.sh` passes with no errors
 - [ ] Skill `name` field matches directory name
-- [ ] `README.md` has all required sections (What It Does, Requirements, Usage, Configuration)
+- [ ] `description` ends with a period and is verb-first
+- [ ] `description` in SKILL.md frontmatter matches README line 3 AND the root README table cell verbatim
+- [ ] `README.md` has all required sections (What It Does, Requirements, Usage, Configuration, Safety if applicable)
+- [ ] Configuration table has rows for `Model`, `Effort`, `Takes argument`, `Allowed tools`
+- [ ] `Allowed tools` row matches the SKILL.md `allowed-tools` frontmatter exactly
+- [ ] Usage examples invoke `/<skill-name>` (not a stale name or another command)
+- [ ] If the skill uses `Agent` + Explore subagents: canonical IMPORTANT subagent block is present in the body
+- [ ] If `EnterPlanMode` is declared in `allowed-tools`: `ExitPlanMode` is paired in both frontmatter and body
 - [ ] Skills table in root `README.md` is updated (if adding/removing a skill)
-- [ ] `CHANGELOG.md` is updated
+- [ ] `CHANGELOG.md` is updated under `## [Unreleased]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ Every `SKILL.md` must begin with YAML frontmatter between `---` delimiters.
 | Field | Description |
 |-------|-------------|
 | `name` | Skill identifier, must match the directory name (e.g., `enhance` for `skills/enhance/`) |
-| `description` | One-line summary of what the skill does |
-| `allowed-tools` | Comma-separated list of tools the skill may use |
+| `description` | One-line summary of what the skill does. Must end with a period and should be verb-first ("Scans...", "Audits...", "Performs..."). The same text must appear verbatim as the README first-line description and as the row in the root README skills table — `lint.sh` enforces all three matches. |
+| `allowed-tools` | Comma-separated list of tools the skill may use. The same list (in the same order) must appear in the README's `Configuration` table `Allowed tools` row — `lint.sh` enforces this parity. |
 
 **Optional fields:**
 
@@ -38,18 +38,19 @@ The body contains the prompt that Claude follows when the skill is invoked. Conv
 
 - Use clear step numbering for multi-phase workflows
 - Use `---` separators between major phases
-- If the skill uses subagents, explicitly state the required `subagent_type` and `model`
-- If the skill enters plan mode, the first instruction should be to call `EnterPlanMode` and the last should call `ExitPlanMode`
+- The first instruction should be the canonical line `` Call `EnterPlanMode` immediately before doing anything else. `` whenever `EnterPlanMode` is declared in `allowed-tools` (`lint.sh` enforces matched-pair body references for both `EnterPlanMode` and `ExitPlanMode`)
+- If the skill uses subagents (`Agent` in `allowed-tools` + `subagent_type: "Explore"` in the body), include the canonical IMPORTANT block verbatim from `create-skill` R4 explaining Explore read-only safety and the Opus model override. `lint.sh` warns when this block is missing.
+- Agent subheadings use `### Agent N: <Title>` (not `**Agent N:**`)
 
 ## README Convention
 
 Every skill's `README.md` must contain these sections (in order):
 
-1. **Title** — `# <Skill Name>` followed by a one-line description
-2. **What It Does** — Describe the workflow and phases
+1. **Title** — `# <Skill Name>` followed by a one-line description on line 3 that matches the SKILL.md `description` field verbatim (`lint.sh` enforces this)
+2. **What It Does** — Describe the workflow and phases. Use "delivered in N steps:" for step-numbered skills or "Runs a strategic N-phase analysis…" for phase-numbered skills.
 3. **Requirements** — Model access, dependencies, prerequisites
-4. **Usage** — How to invoke (e.g., `/<skill-name>` or `/<skill-name> <argument>`)
-5. **Configuration** — Table of frontmatter settings
+4. **Usage** — How to invoke. Examples must use the skill's actual name (`/<skill-name>` — `lint.sh` enforces this).
+5. **Configuration** — Table of frontmatter settings with required rows: `Model`, `Effort`, `Takes argument`, `Allowed tools`. The `Allowed tools` row must list the same tools as the SKILL.md `allowed-tools` frontmatter (`lint.sh` enforces this parity).
 6. **Safety** (if applicable) — What the skill can and cannot modify
 
 See `skills/enhance/README.md` as the reference implementation.
@@ -60,10 +61,11 @@ See `skills/enhance/README.md` as the reference implementation.
 2. Fill in the SKILL.md frontmatter and prompt
 3. Fill in the README.md sections
 4. Ensure the `name` field in frontmatter matches the directory name
-5. Run `./lint.sh <name>` to validate
-6. Update the skills table in the root `README.md`
-7. Run `./install.sh <name>` to create the symlink
-8. Commit and push
+5. Update the skills table in the root `README.md` (the table cell must match the SKILL.md `description` verbatim)
+6. Update `CHANGELOG.md` with the new skill under `## [Unreleased]` — `release.yml` extracts release notes from this section, so missing the update silently breaks the next release
+7. Run `./lint.sh <name>` to validate (and `./lint.sh` to confirm no regressions on the other skills)
+8. Run `./install.sh <name>` to create the symlink
+9. Commit and push
 
 ## Quality Standards
 
@@ -78,6 +80,13 @@ See `skills/enhance/README.md` as the reference implementation.
 
 Run `./lint.sh` to check all skills, or `./lint.sh <name>` for a specific skill. The linter checks:
 
-- Required frontmatter fields exist
+- Required frontmatter fields exist (`name`, `description`, `allowed-tools`)
 - Skill name matches directory name
+- Description ends with a period
+- `EnterPlanMode` and `ExitPlanMode` are paired in `allowed-tools` AND referenced in the body when present
+- Canonical IMPORTANT subagent block is present when `Agent` is paired with Explore subagents
 - README.md exists with required sections
+- README line 3 description matches SKILL.md `description` verbatim
+- Usage examples invoke the correct `/<skill-name>` (not stale names or unrelated commands)
+- Configuration table has `Takes argument` and `Allowed tools` rows
+- `Allowed tools` row matches SKILL.md `allowed-tools` frontmatter (whitespace-normalized)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Before writing code, [open a Skill Request issue](https://github.com/thijsvos/Cl
    ```yaml
    ---
    name: my-skill
-   description: What the skill does
+   description: Verb-first one-line summary of what the skill does, ending with a period.
    allowed-tools: Read, Grep, Glob
    model: opus          # optional: opus, sonnet, haiku
    effort: max          # optional: min, low, medium, high, max

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ A curated collection of custom skills for [Claude Code](https://docs.anthropic.c
 
 | Skill | Description | Model | Effort |
 |-------|-------------|-------|--------|
-| [enhance](skills/enhance/) | Performs deep multi-phase project analysis to identify and recommend the single most impactful addition to implement | Opus | Max |
-| [github-audit](skills/github-audit/) | Audits a GitHub repository against best practices and provides prioritized recommendations | Opus | Max |
-| [code-review](skills/code-review/) | Structured code review with prioritized findings and fix offers | Opus | Max |
-| [test-gen](skills/test-gen/) | Comprehensive test generation with deep code analysis, convention detection, and edge case coverage | Opus | Max |
-| [dep-check](skills/dep-check/) | Scans dependencies across ecosystems for updates and vulnerabilities, produces a prioritized update plan | Opus | Max |
-| [diagnose](skills/diagnose/) | Multi-agent root cause analysis with error tracing, change correlation, and ranked fix hypotheses | Opus | Max |
-| [refactor](skills/refactor/) | Comprehensive refactoring across correctness, security, performance, and maintainability with behavior-preserving changes | Opus | Max |
-| [create-skill](skills/create-skill/) | Interactive skill generator that scaffolds new skills following all project conventions | Opus | Max |
-| [docstring-check](skills/docstring-check/) | Scans a codebase for missing, outdated, drifted, or inconsistent docstrings and applies convention-matching fixes | Opus | Max |
-| [github-ship](skills/github-ship/) | Turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged. Auto-detects which | Opus | Max |
-| [idiom-check](skills/idiom-check/) | Audits a codebase through a programming-language-specific idiom lens, produces a prioritized report, and offers remediation in PR-sized bundles | Opus | Max |
+| [enhance](skills/enhance/) | Performs deep multi-phase project analysis to identify and recommend the single most impactful addition to implement. | Opus | Max |
+| [github-audit](skills/github-audit/) | Audits a GitHub repository against best practices and provides prioritized recommendations for README, license, community health, CI/CD, and repository settings. | Opus | Max |
+| [code-review](skills/code-review/) | Structured code review across correctness, security, performance, and conventions with prioritized findings and fix offers. | Opus | Max |
+| [test-gen](skills/test-gen/) | Analyzes code to generate comprehensive tests covering happy paths, edge cases, error handling, and integration points, matching the project's existing test conventions. | Opus | Max |
+| [dep-check](skills/dep-check/) | Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations. | Opus | Max |
+| [diagnose](skills/diagnose/) | Multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses. | Opus | Max |
+| [refactor](skills/refactor/) | Comprehensive code refactoring across correctness, security, performance, and maintainability with behavior-preserving, incremental changes. | Opus | Max |
+| [create-skill](skills/create-skill/) | Interactive skill generator that scaffolds new skills following all project conventions, serving as the definitive reference for skill creation. | Opus | Max |
+| [docstring-check](skills/docstring-check/) | Scans a codebase for missing, outdated, drifted, or inconsistent docstrings and applies behavior-preserving fixes matching the project's detected convention. | Opus | Max |
+| [github-ship](skills/github-ship/) | Turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged. Auto-detects which. | Opus | Max |
+| [idiom-check](skills/idiom-check/) | Audits a codebase through a programming-language-specific idiom lens, produces a prioritized report, and offers remediation in PR-sized bundles. | Opus | Max |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Four documentation/convention alignments from the `/code-review` audit. All doc edits — no behavior changes.

- **[W7]** Root README skills-table descriptions now match each `SKILL.md` `description` field verbatim. Previously 6 of 11 cells diverged (different phrasing for `test-gen`, `dep-check`, `diagnose`, `refactor`; missing trailing periods on `enhance` and `github-ship`). Same canonical description in SKILL.md frontmatter + README line 3 + root README table cell — which is exactly what `lint.sh` already enforces for two of those three locations.
- **[W8]** `CLAUDE.md` now documents what `lint.sh` actually enforces: description must end with a period; Configuration table requires `Model`/`Effort`/`Takes argument`/`Allowed tools` rows; `Allowed tools` row must match SKILL.md frontmatter verbatim; canonical IMPORTANT subagent block required when `Agent` + Explore are used; `### Agent N:` subheading style. Validation section now lists all 11 lint checks explicitly.
- **[W9]** PR template checklist expanded from 5 items to 12 to cover the v0.1.0 lint rules contributors might forget (description period, three-way verbatim description match, Configuration row parity, IMPORTANT block presence, `EnterPlanMode`/`ExitPlanMode` pairing).
- **[W13]** `CLAUDE.md` "Adding a New Skill" step list now mentions `CHANGELOG.md` (previously omitted — silently broke `release.yml`'s notes extraction). Step order reconciled with `CONTRIBUTING.md` so contributors following either doc reach the same end state. `CONTRIBUTING.md` sample frontmatter now ends with a period.

## Test plan

- [x] `./lint.sh` passes (241 checks)
- [x] All 11 skills' root README cells now match their SKILL.md description (verified by diff)
- [ ] After merge: a future skill addition that follows CLAUDE.md alone should pass lint without needing to consult CONTRIBUTING.md

## Note

This PR will conflict with PR #62 (B1 — CI/release hardening) only if both modify the same file, which they don't — B1 is workflow YAML, B2 is Markdown docs. Should merge cleanly in either order.
