### PR TITLE
Polish: gitignore, editorconfig, dependabot, templates, SECURITY

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,13 @@ insert_final_newline = true
 [*.sh]
 indent_size = 4
 
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+# Markdown uses two trailing spaces as a hard line break — preserve them.
+trim_trailing_whitespace = false
+
 [Makefile]
 indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a broken or misbehaving skill
+title: "[Bug] "
 labels: ["bug"]
 body:
   - type: input
@@ -27,11 +28,15 @@ body:
         2. ...
     validations:
       required: true
-  - type: input
+  - type: dropdown
     id: model
     attributes:
       label: Model
       description: Which Claude model were you using?
-      placeholder: e.g., claude-opus-4-7
+      options:
+        - Haiku
+        - Sonnet
+        - Opus
+        - Other / not sure
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/skill_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_request.yml
@@ -1,5 +1,6 @@
 name: Skill Request
 description: Propose a new skill for the collection
+title: "[Skill Request] "
 labels: ["enhancement"]
 body:
   - type: input

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "ci"
+      - "dependencies"
+    open-pull-requests-limit: 5
+    # Batch all GitHub Actions updates into a single weekly PR — keeps noise
+    # down given the repo only has one action pinned at a time.
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,24 @@
 .DS_Store
 ._*
+Thumbs.db
 *.swp
 *.swo
 *~
 .vscode/
 .idea/
-.claude/
+# Per-user Claude Code config only — the project-level `.claude/` directory
+# is tracked. Adding the whole `.claude/` here would silently swallow new
+# tracked files added under it.
+.claude/local/
+.claude/settings.local.json
 *.bak
 .env*
 *.log
 node_modules/
 __pycache__/
+.pytest_cache/
+.coverage
+htmlcov/
+*.egg-info/
+venv/
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [0.1.1] - 2026-05-14
 
 ### Changed
-- Bash function comment headers added/expanded across `install.sh` and `lint.sh` (`docstring-check` audit). `install_skill`, `lint_skill`, and `restore_on_exit` now have block-comment headers documenting purpose, args, return semantics, and side effects (mutated globals `PENDING_TARGET`/`PENDING_BACKUP`, counter mutations `TOTAL_*`, EXIT/INT/TERM trap role). `emit`'s mixed block + inline arg comment collapsed into a single block header that notes the deliberate non-mutation of counters (no summary block in install.sh). The shared `pass`/`fail`/`warn` header now documents the load-bearing `TOTAL_FAIL > 0 → exit 1` contract that was previously implicit. `get_frontmatter`'s header tightened to specify the no-output-on-key-absent return convention and the don't-trim-trailing-whitespace contract. Comment-only — no behavior or output changes.
+- Bash function comment headers added/expanded across `install.sh` and `lint.sh` (`docstring-check` audit). Comment-only — no behavior or output changes:
+  - `install_skill`, `lint_skill`, and `restore_on_exit` gained block-comment headers documenting purpose, args, return semantics, and side effects (mutated globals `PENDING_TARGET`/`PENDING_BACKUP`, counter mutations `TOTAL_*`, EXIT/INT/TERM trap role).
+  - `emit`'s mixed block + inline arg comment was collapsed into a single block header that notes the deliberate non-mutation of counters (no summary block in install.sh).
+  - The shared `pass`/`fail`/`warn` header now documents the load-bearing `TOTAL_FAIL > 0 → exit 1` contract that was previously implicit.
+  - `get_frontmatter`'s header was tightened to specify the no-output-on-key-absent return convention and the don't-trim-trailing-whitespace contract.
 
 ## [0.1.0] - 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - **Propose a skill**: [open a Skill Request](https://github.com/thijsvos/Claude_Skills/issues/new?template=skill_request.yml)
 - **Report a bug**: [open a Bug Report](https://github.com/thijsvos/Claude_Skills/issues/new?template=bug_report.yml)
 - **Security issues**: see [SECURITY.md](SECURITY.md)
+- **Community standards**: see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,10 @@ Claude Code skills are prompt-based extensions that can request access to powerf
 
 **Users should review any skill's `SKILL.md` before installing it**, paying particular attention to the `allowed-tools` field and the prompt content.
 
+## Supported Versions
+
+This repo is forward-only: skills are distributed via symlinks from the latest tag/`main`, so security fixes land in whichever release is current. Only the latest tagged release (see [CHANGELOG.md](CHANGELOG.md)) receives security fixes. To pick up patches, run `git pull` in the cloned repo — your symlinks update automatically.
+
 ## Reporting a Vulnerability
 
 If you discover a security issue in a skill (e.g., a skill that exfiltrates data, executes unintended commands, or requests excessive permissions), please report it responsibly:
@@ -17,7 +21,7 @@ If you discover a security issue in a skill (e.g., a skill that exfiltrates data
 1. **Do not open a public issue.** Security vulnerabilities should be reported privately.
 2. **Use [GitHub Security Advisories](https://github.com/thijsvos/Claude_Skills/security/advisories/new)** to report the issue privately.
 
-You should receive an acknowledgment within 48 hours and a resolution timeline within 7 days.
+This is a maintainer-led project, so response times are best-effort: we aim to acknowledge reports within 7 days and provide a resolution timeline within 30 days. Critical issues are prioritized.
 
 ## What Counts as a Security Issue
 

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,13 @@ restore_on_exit() {
     local rc=$?
     if [[ -n "$PENDING_BACKUP" && -n "$PENDING_TARGET" ]]; then
         if [[ ! -L "$PENDING_TARGET" && ! -e "$PENDING_TARGET" && -e "$PENDING_BACKUP" ]]; then
-            mv "$PENDING_BACKUP" "$PENDING_TARGET" 2>/dev/null || true
+            # Loud failure: if the rollback itself fails, the user must know
+            # the backup is still at the .bak path — otherwise they'll think
+            # the install completed and lose track of the recovery file.
+            if ! mv "$PENDING_BACKUP" "$PENDING_TARGET"; then
+                printf 'WARNING: failed to restore %s from %s; backup left in place\n' \
+                    "$PENDING_TARGET" "$PENDING_BACKUP" >&2
+            fi
         fi
     fi
     exit "$rc"


### PR DESCRIPTION
## Summary

Ten small fixes/polish from the `/code-review` audit. Touches 9 files but each change is small and orthogonal — no behavior changes outside the install.sh warning message.

### Fixed (real correctness/maintenance)

- **[W5]** `.gitignore` no longer ignores the whole `.claude/` directory (which is project-tracked). Narrowed to `.claude/local/` and `.claude/settings.local.json` — per-user files only. Closes the silent-`git add` trap where new files under `.claude/` would be invisible to git.
- **[W6]** `install.sh` `restore_on_exit` prints a loud warning to stderr if the rollback `mv` itself fails, so users know the backup is still at the `.bak` path. Previously swallowed via `|| true`.
- **[W10]** Issue templates gain `title:` prefills (`[Bug] `, `[Skill Request] `) for triage searchability; `bug_report.yml`'s `model` input converted to a `dropdown` for consistency with `skill_request.yml`.
- **[W11]** `SECURITY.md` SLA softened from "48h ack / 7d resolution" to best-effort "7d ack / 30d resolution" — more realistic for a maintainer-led repo and less likely to be missed.
- **[W12]** `CHANGELOG.md` v0.1.1 entry restructured from one ~30-line paragraph into a top-line summary + 4 sub-bullets (one per affected helper). Easier to scan.
- **[W14]** `.editorconfig` adds explicit `[*.{yml,yaml}]` (2-space) and `[*.md]` (2-space + `trim_trailing_whitespace = false` to preserve hard line breaks).

### Hardening / polish

- **[S4]** `dependabot.yml` gains `labels: [ci, dependencies]`, `open-pull-requests-limit: 5`, a `groups.actions` block that batches all action updates into one weekly PR, and `commit-message: prefix: ci` for consistency.
- **[S6]** `SECURITY.md` adds a "Supported Versions" section explaining the forward-only `git pull` model — matches GitHub's default SECURITY.md template structure.
- **[S7]** `.gitignore` adds Python (`venv/`, `.venv/`, `.pytest_cache/`, `.coverage`, `htmlcov/`, `*.egg-info/`) and Windows (`Thumbs.db`) entries to cover contributor prototyping artifacts.
- **[S8]** README "Contributing" section now links `CODE_OF_CONDUCT.md` alongside CONTRIBUTING, issue templates, and SECURITY.md.

### Test plan

- [x] `./lint.sh` passes (241 checks)
- [x] `bash -n install.sh` clean
- [ ] After merge: an interrupted install (simulate via `kill -INT $$` between `mv` and `ln`) should print the loud warning
- [ ] After merge: filing a bug should pre-fill `[Bug] ` in the title

## Note

This PR touches `install.sh`, `CHANGELOG.md`, `README.md`, and several other files. Will conflict trivially with PR #62 (B1 — workflow YAML, different files) and PR #63 (B2 — `CLAUDE.md`/`CONTRIBUTING.md`/PR template/README skills table). The README conflict is in different sections (B2 changes table cells lines 14-24; this PR adds a line at line 134); should be a clean 3-way merge. If not, B2 should merge first, then this PR rebases.
