### PR TITLE
Add per-skill Example sections for output discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Per-skill `## Example` sections** in every skill README (`skills/*/README.md`), placed between `## Usage` and `## Configuration`. Each example shows a 1-line scenario, the exact invocation, and an abbreviated transcript using the skill's real distinctive output surface (e.g., `code-review`'s `NEEDS CHANGES ✗` verdict, `dep-check`'s `[V1]` vulnerability format, `idiom-check`'s Remediation Bundle table). Long transcripts are wrapped in `<details><summary>Sample output</summary>…</details>` so the README stays scannable.
+- **`Example` column in the root README skills table** with deep-links to each skill's new `#example` anchor — turns the catalogue into a thumbnail gallery.
+- **`templates/README.md`** gains an `## Example` skeleton between Usage and Configuration so new skills inherit the convention.
+- **`create-skill` R11 (README Sections)** documents the new `## Example` section, explicitly noting it's exempt from the `## Usage` cross-skill awk check so handoff examples (e.g., a `github-audit` example referencing `/dep-check`) are safe inside `## Example`.
+- **`lint.sh`** gains a soft `[warn]` if a skill README lacks `## Example` — non-blocking drift prevention modeled on the existing `## Safety` warn rule.
+
 ## [0.2.0] - 2026-05-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ A curated collection of custom skills for [Claude Code](https://docs.anthropic.c
 
 ## Available Skills
 
-| Skill | Description | Model | Effort |
-|-------|-------------|-------|--------|
-| [enhance](skills/enhance/) | Performs deep multi-phase project analysis to identify and recommend the single most impactful addition to implement. | Opus | Max |
-| [github-audit](skills/github-audit/) | Audits a GitHub repository against best practices and provides prioritized recommendations for README, license, community health, CI/CD, and repository settings. | Opus | Max |
-| [code-review](skills/code-review/) | Structured code review across correctness, security, performance, and conventions with prioritized findings and fix offers. | Opus | Max |
-| [test-gen](skills/test-gen/) | Analyzes code to generate comprehensive tests covering happy paths, edge cases, error handling, and integration points, matching the project's existing test conventions. | Opus | Max |
-| [dep-check](skills/dep-check/) | Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations. | Opus | Max |
-| [diagnose](skills/diagnose/) | Multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses. | Opus | Max |
-| [refactor](skills/refactor/) | Comprehensive code refactoring across correctness, security, performance, and maintainability with behavior-preserving, incremental changes. | Opus | Max |
-| [create-skill](skills/create-skill/) | Interactive skill generator that scaffolds new skills following all project conventions, serving as the definitive reference for skill creation. | Opus | Max |
-| [docstring-check](skills/docstring-check/) | Scans a codebase for missing, outdated, drifted, or inconsistent docstrings and applies behavior-preserving fixes matching the project's detected convention. | Opus | Max |
-| [github-ship](skills/github-ship/) | Turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged. Auto-detects which. | Opus | Max |
-| [idiom-check](skills/idiom-check/) | Audits a codebase through a programming-language-specific idiom lens, produces a prioritized report, and offers remediation in PR-sized bundles. | Opus | Max |
+| Skill | Description | Model | Effort | Example |
+|-------|-------------|-------|--------|---------|
+| [enhance](skills/enhance/) | Performs deep multi-phase project analysis to identify and recommend the single most impactful addition to implement. | Opus | Max | [view](skills/enhance/README.md#example) |
+| [github-audit](skills/github-audit/) | Audits a GitHub repository against best practices and provides prioritized recommendations for README, license, community health, CI/CD, and repository settings. | Opus | Max | [view](skills/github-audit/README.md#example) |
+| [code-review](skills/code-review/) | Structured code review across correctness, security, performance, and conventions with prioritized findings and fix offers. | Opus | Max | [view](skills/code-review/README.md#example) |
+| [test-gen](skills/test-gen/) | Analyzes code to generate comprehensive tests covering happy paths, edge cases, error handling, and integration points, matching the project's existing test conventions. | Opus | Max | [view](skills/test-gen/README.md#example) |
+| [dep-check](skills/dep-check/) | Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations. | Opus | Max | [view](skills/dep-check/README.md#example) |
+| [diagnose](skills/diagnose/) | Multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses. | Opus | Max | [view](skills/diagnose/README.md#example) |
+| [refactor](skills/refactor/) | Comprehensive code refactoring across correctness, security, performance, and maintainability with behavior-preserving, incremental changes. | Opus | Max | [view](skills/refactor/README.md#example) |
+| [create-skill](skills/create-skill/) | Interactive skill generator that scaffolds new skills following all project conventions, serving as the definitive reference for skill creation. | Opus | Max | [view](skills/create-skill/README.md#example) |
+| [docstring-check](skills/docstring-check/) | Scans a codebase for missing, outdated, drifted, or inconsistent docstrings and applies behavior-preserving fixes matching the project's detected convention. | Opus | Max | [view](skills/docstring-check/README.md#example) |
+| [github-ship](skills/github-ship/) | Turns local changes into a GitHub issue and linked PR, or cleans up the branch if the PR was already merged. Auto-detects which. | Opus | Max | [view](skills/github-ship/README.md#example) |
+| [idiom-check](skills/idiom-check/) | Audits a codebase through a programming-language-specific idiom lens, produces a prioritized report, and offers remediation in PR-sized bundles. | Opus | Max | [view](skills/idiom-check/README.md#example) |
 
 ## Quick Start
 

--- a/lint.sh
+++ b/lint.sh
@@ -205,6 +205,16 @@ lint_skill() {
         warn "README has no Safety section (optional)"
     fi
 
+    # README discoverability: Example section is recommended (non-blocking).
+    # Catches drift on new skills that forget to include sample output, which
+    # is the strongest "is this the skill I need?" signal for users browsing
+    # the catalogue. Non-fatal so existing forks keep linting clean.
+    if grep -qi "## Example" "$readme_md"; then
+        pass "README has section: Example"
+    else
+        warn "README has no Example section (recommended — adds a sample-output transcript)"
+    fi
+
     # README first line description should match SKILL.md description
     # (skip the "# Title" heading — line 3 is the description in the README template).
     # Read exactly three lines natively instead of spawning `sed -n '3p'`; the

--- a/skills/code-review/README.md
+++ b/skills/code-review/README.md
@@ -26,6 +26,49 @@ Analyzes code changes across multiple quality dimensions using parallel AI agent
 /code-review HEAD~3..HEAD       # Review a specific commit range
 ```
 
+## Example
+
+Reviewing a recent change to an auth handler:
+
+```
+/code-review src/auth/handler.ts
+```
+
+<details>
+<summary>Sample report</summary>
+
+```
+## Code Review: src/auth/handler.ts
+
+**Scope**: 1 file changed (+47, -12) | **Findings**: 1 critical, 2 warnings, 3 suggestions
+
+### Verdict: NEEDS CHANGES ✗
+
+Token validation is bypassable on the refresh path; addressing C1 unblocks ship.
+
+---
+
+### Critical
+
+**[C1]** `src/auth/handler.ts:88` — Refresh token reused after rotation
+The refresh-token branch returns the *old* token to the client even after rotating server-side, leaving the previous token valid for the full TTL.
+**Fix:** Return the rotated token from `rotateRefreshToken()` rather than the parameter passed in.
+
+### Warnings
+
+**[W1]** `src/auth/handler.ts:42` — Missing rate-limit on `/login` …
+**[W2]** `src/auth/handler.ts:115` — Sensitive error returned to client …
+
+### Looks Good
+
+- Session expiry uses `crypto.timingSafeEqual` — constant-time comparison is the idiomatic Node choice.
+- New tests in `handler.test.ts` cover the rotation path end-to-end.
+```
+
+</details>
+
+> **Want me to fix any of these?** (e.g., "fix C1 and W2", "fix all critical")
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/create-skill/README.md
+++ b/skills/create-skill/README.md
@@ -26,6 +26,47 @@ The SKILL.md itself contains a comprehensive **Skill Creation Reference** that d
 /create-skill                                       # No argument -- will ask what to create
 ```
 
+## Example
+
+Scaffolding a new "C# security audit" skill from scratch:
+
+```
+/create-skill "security audit for C# codebases"
+```
+
+<details>
+<summary>Sample flow</summary>
+
+```
+[Step 1] Gathering requirements via batched AskUserQuestion …
+  ✓ Argument behavior: Optional argument
+  ✓ Capabilities: Modify existing files, Internet access
+  ✓ Subagent fan-out: 3 Explore subagents — three orthogonal analysis lenses
+
+[Step 2] Designed skill: name=csharp-security, prefix=[S1], 3 lenses
+        (OWASP / .NET-specific weaknesses / build config)
+
+[Step 3] Generated SKILL.md + README.md previews (presented inline for review).
+
+> **Ready to create this skill?** (e.g., "yes", "change the name to X")
+
+[After approval]
+
+> **Skill created and installed.** `/csharp-security` is ready to use.
+>
+> Files created:
+> - `skills/csharp-security/SKILL.md`
+> - `skills/csharp-security/README.md`
+>
+> Files updated:
+> - `README.md` (skills table)
+> - `CHANGELOG.md` (Unreleased section)
+>
+> Run `/csharp-security` to try it out.
+```
+
+</details>
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -318,8 +318,9 @@ Every skill's `README.md` must contain these sections **in this order**:
    - For phase-numbered skills: *"Runs a strategic N-phase analysis…"* or *"Runs an N-phase audit…"*
 3. **Requirements** — model access, dependencies, prerequisites
 4. **Usage** — how to invoke (e.g., `/<skill-name>` or `/<skill-name> <argument>`). Examples MUST use the skill's actual name in the slash command.
-5. **Configuration** — table of frontmatter settings. Required rows: `Model`, `Effort`, `Takes argument`, `Allowed tools`. The `Allowed tools` row must list the SAME tools as the SKILL.md `allowed-tools` frontmatter (including `EnterPlanMode`/`ExitPlanMode` if they're there).
-6. **Safety** — bullet points with bold labels describing what the skill can and cannot do
+5. **Example** — a 1-line scenario, the exact invocation, and a faithful abbreviated transcript wrapped in `<details><summary>Sample output</summary>…</details>`. Use the skill's real format strings (verdict banners, finding-ID prefix, report headings) so users can recognize the output before they install. Avoid `## Usage`-style slash-command lines that reference OTHER skills inside `## Usage` (the linter scans Usage for cross-skill references); `## Example` is exempt from that check by design. Keep the visible part under ~25 lines.
+6. **Configuration** — table of frontmatter settings. Required rows: `Model`, `Effort`, `Takes argument`, `Allowed tools`. The `Allowed tools` row must list the SAME tools as the SKILL.md `allowed-tools` frontmatter (including `EnterPlanMode`/`ExitPlanMode` if they're there).
+7. **Safety** — bullet points with bold labels describing what the skill can and cannot do
 
 The **Safety** section uses this pattern:
 ```

--- a/skills/dep-check/README.md
+++ b/skills/dep-check/README.md
@@ -26,6 +26,63 @@ Performs a comprehensive dependency audit across every ecosystem present in the 
 /dep-check docker                 # Check only Docker base image versions
 ```
 
+## Example
+
+Auditing a Python project with two outdated packages and one published CVE:
+
+```
+/dep-check python
+```
+
+<details>
+<summary>Sample report</summary>
+
+```
+## Dependency Report: my-app
+
+**Scanned**: 2 manifest files across 1 ecosystem | **Dependencies**: 47
+**Updates available**: 12 | **Vulnerabilities**: 1 (1 high)
+
+---
+
+### Security Vulnerabilities (act immediately)
+
+**[V1]** `requests` 2.28.1 — CVE-2024-35195: cert verification bypass via session reuse
+Severity: **high** | File: `requirements.txt`
+Fixed in: `2.32.0`
+Update command:
+    pip install --upgrade "requests>=2.32.0"
+
+---
+
+### Update Plan
+
+#### Group 1: Security patches (no breaking changes expected)
+**Risk**: Low | **Effort**: Minimal
+
+| Package  | Current | Target | Delta | File             |
+|----------|---------|--------|-------|------------------|
+| requests | 2.28.1  | 2.32.3 | minor | requirements.txt |
+
+#### Group 2: Minor updates (backward-compatible)
+**Risk**: Low-Medium | **Effort**: Minimal
+
+| Package  | Current | Target | Delta | File             |
+|----------|---------|--------|-------|------------------|
+| httpx    | 0.27.0  | 0.27.2 | patch | requirements.txt |
+| pydantic | 2.5.0   | 2.7.4  | minor | requirements.txt |
+
+---
+
+### Already Up to Date
+
+11 dependencies are already at their latest version.
+```
+
+</details>
+
+> **Want me to apply any of these updates?** (e.g., "apply all", "apply security patches only", "apply V1")
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/diagnose/README.md
+++ b/skills/diagnose/README.md
@@ -25,6 +25,54 @@ Performs structured root cause analysis through parallel investigation, delivere
 /diagnose                                 # Auto-detect: check recent test/CI failures
 ```
 
+## Example
+
+Tracking down a runtime TypeError that surfaced after a refactor:
+
+```
+/diagnose "TypeError: Cannot read properties of undefined (reading 'map')"
+```
+
+<details>
+<summary>Sample report</summary>
+
+```
+## Debug Report: TypeError on `users.map(...)` in dashboard render
+
+**Error**: TypeError: Cannot read properties of undefined (reading 'map')
+**Location**: `src/dashboard/UserList.tsx:54` | **Category**: runtime
+
+---
+
+### Root Cause
+
+**[H1]** Empty-response shape changed from `[]` to `undefined` — Confidence: **High**
+`src/api/users.ts:88` — A recent refactor switched the no-users path from `return []`
+to `return data?.users`, but the dashboard still calls `.map(...)` without guarding.
+
+**Evidence:**
+- Commit `a3f12c4` (3 days ago) changed `return users || []` to `return data?.users`.
+- That commit was the last to touch `src/api/users.ts` before the error appeared.
+- `UserList.tsx:54` calls `.map` directly on the response.
+
+**Fix:**
+    const users = (await fetchUsers()) ?? [];
+    return users.map(...);
+
+**Why this fixes it:** Restores the empty-array invariant the caller already depends on.
+
+---
+
+### Alternative Hypotheses
+
+**[H2]** Network failure returning `undefined` instead of throwing — Confidence: Medium
+**[H3]** Race condition on initial render — Confidence: Low
+```
+
+</details>
+
+> **Want me to apply the fix?** (e.g., "apply H1", "let me try H1 first")
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/docstring-check/README.md
+++ b/skills/docstring-check/README.md
@@ -31,6 +31,60 @@ The key behaviors are **convention-matching** (fixes adopt the project's detecte
 /docstring-check "the public API"             # Natural language scope description
 ```
 
+## Example
+
+Auditing a Python module after a signature refactor:
+
+```
+/docstring-check src/users.py
+```
+
+<details>
+<summary>Sample plan</summary>
+
+```
+## Docstring Plan: src/users.py
+
+**Scope**: 1 file, 12 documentable symbols inspected | **Findings**: 4 (1 missing, 2 drift, 1 style)
+**Detected style**: Google
+**Linters run**: ruff (D rules)
+
+### Verification Strategy
+Linter available — will re-run `ruff check --select D src/users.py` after fixes.
+
+---
+
+### Signature / Content Drift
+
+**[D1]** `src/users.py:88` — `def update_user(uid, **kwargs)`
+**Current**:
+    """Update a user.
+
+    Args:
+        user_id: The ID of the user to update.
+        name: The new name.
+    """
+
+**Proposed**:
+    """Update a user.
+
+    Args:
+        uid: The ID of the user to update.
+        **kwargs: Fields to update. Supported keys: name, email, role.
+    """
+**Why**: Docstring still names `user_id` and `name` after the signature switched to `uid` + `**kwargs`.
+
+---
+
+### Missing Docstrings — Public API
+
+**[D3]** `src/users.py:142` — `class UserRegistry` — Critical
+```
+
+</details>
+
+> **Ready to apply these docstring fixes?** (e.g., "apply all", "apply D1 through D3", "apply public API only")
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/enhance/README.md
+++ b/skills/enhance/README.md
@@ -33,6 +33,49 @@ The skill automatically:
 4. Presents a final recommendation with implementation sketch
 5. Exits plan mode and offers to implement
 
+## Example
+
+Running `/enhance` against a CLI tool repo that has no observability story:
+
+```
+/enhance
+```
+
+<details>
+<summary>Sample recommendation</summary>
+
+```
+### The Enhancement
+Structured JSON logging behind a `--log-format` flag.
+
+### Why This?
+- The tool already emits 14 distinct log lines; teams running it in CI have no way
+  to grep them apart from incidental command output.
+- One small flag unlocks downstream ingestion into Loki/Datadog with zero new deps.
+- Compounds: once logs are structured, every future command inherits observability.
+
+### What You Considered (and Why Not)
+- A full OpenTelemetry tracing layer — overkill for a synchronous CLI.
+- A separate `--verbose` mode — addresses the wrong axis (volume, not structure).
+- A `--metrics` Prometheus exporter — wrong target audience for this tool.
+
+### Implementation Sketch
+Add a `LogFormat` enum to `src/cli/flags.rs`, plumb it into the existing
+`println!`-based emit helpers via a `Logger` struct. Default = `text` (no behavior change);
+`json` emits one line per event with `ts`, `level`, `event`, `fields` keys.
+
+### Expected Impact
+Immediate: CI users can `grep '"level":"error"'`. Compounding: structured logs become
+the substrate for a future `--metrics` exporter or a `replay` subcommand.
+
+### Scope & Path
+**Medium** (~3 hours). Wire flag → write Logger → migrate ~14 call sites → snapshot tests.
+```
+
+</details>
+
+> **Want me to implement this now?**
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/github-audit/README.md
+++ b/skills/github-audit/README.md
@@ -24,6 +24,49 @@ Runs a 3-phase audit of your repository's GitHub presence:
 
 The skill enters plan mode automatically, performs the audit using read-only Explore subagents, asks about your project's intended audience to calibrate recommendations, then presents findings and offers to implement improvements.
 
+## Example
+
+Auditing a Rust library that just went public:
+
+```
+/github-audit
+```
+
+<details>
+<summary>Sample report</summary>
+
+```
+### Repository Scorecard
+
+| Category               | Status            | Priority |
+|------------------------|-------------------|----------|
+| README Quality         | Needs improvement | High     |
+| License                | Good              | —        |
+| Community Health       | Missing           | Medium   |
+| CI/CD & Automation     | Good              | —        |
+| Repository Settings    | Needs improvement | High     |
+| Git Hygiene            | Good              | —        |
+| Documentation          | Needs improvement | Medium   |
+
+### Top Recommendations
+
+#### 1. Add a `CODE_OF_CONDUCT.md` and issue templates
+**Category**: Community Health
+**Effort**: Quick fix (< 5 min)
+**Impact**: Signals the project welcomes external contributors; required for some org policies.
+**What to do**: Use the Contributor Covenant 2.1 template and the GitHub default issue forms.
+
+#### 2. Enable Dependabot for `cargo` updates
+**Category**: CI/CD & Automation
+**Effort**: Quick fix (< 5 min)
+**Impact**: Catches CVE-affected crates within a day of disclosure.
+**Skill handoff**: Once enabled, run /dep-check to action the first batch.
+```
+
+</details>
+
+> **Want me to implement any of these recommendations?**
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/github-ship/README.md
+++ b/skills/github-ship/README.md
@@ -40,6 +40,56 @@ Typical flow:
 # It sees the merged PR, switches to cleanup, and deletes the branch.
 ```
 
+## Example
+
+Shipping a small fix from a clean working tree on `main`:
+
+```
+/github-ship
+```
+
+<details>
+<summary>Sample flow</summary>
+
+```
+## Ship Plan
+
+**On**: `main` → `main` on `thijsvos/myapp`
+
+### Actions
+
+- [x] Commit: `Fix off-by-one in pagination cursor`
+- [x] Create branch: `fix/pagination-cursor`
+- [x] Push to origin
+- [ ] Create issue
+- [ ] Create PR linking to the issue
+
+### Issue
+**Title**: Fix off-by-one in pagination cursor
+**Body**: The cursor advance in `paginate.ts` skips the last item on each page boundary …
+
+### Pull Request
+**Title**: Fix off-by-one in pagination cursor
+**Body**:
+> Closes #42
+>
+> ## Summary
+> - Cursor now advances by `pageSize` instead of `pageSize - 1`.
+> …
+
+> **Ship it?** (e.g., "go", "shorten the title")
+
+[After approval]
+
+> **Shipped.**
+> - Issue: https://github.com/thijsvos/myapp/issues/42
+> - PR:    https://github.com/thijsvos/myapp/pull/43
+>
+> Merge the PR on GitHub when ready, then run /github-ship again to clean up.
+```
+
+</details>
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/idiom-check/README.md
+++ b/skills/idiom-check/README.md
@@ -31,6 +31,58 @@ The skill explicitly supports Rust, Python, TypeScript / JavaScript, Go, and Rub
 
 The skill takes no argument. It always audits the whole repository (with optional narrowing to a top-level subdirectory if more than 50 source files are detected).
 
+## Example
+
+Auditing a Rust crate where parser code clones strings unnecessarily:
+
+```
+/idiom-check
+```
+
+<details>
+<summary>Sample audit</summary>
+
+```
+## Idiom Audit: Rust — src/
+
+**Scope**: 14 files, 2,847 total lines | **Language**: Rust (edition 2021)
+**Findings**: 9 total (3 high, 4 medium, 2 low)
+
+---
+
+### High
+
+| ID   | File:Line                  | Title                            | Lens      | Confidence | Risk |
+|------|----------------------------|----------------------------------|-----------|------------|------|
+| [I1] | `src/parser/mod.rs:42`     | `String` arg should be `&str`    | Ownership | High       | Safe |
+| [I2] | `src/parser/tokens.rs:88`  | Unnecessary `.clone()` in loop   | Ownership | High       | Safe |
+| [I3] | `src/lex.rs:115`           | `.unwrap()` on parse boundary    | Types     | High       | Safe |
+
+(detailed `**[I1]**` blocks follow with Current / Idiomatic snippets and "why in THIS codebase" rationale)
+
+---
+
+### Looks Good (do not change)
+
+- Error types use `thiserror` consistently with `#[error]` derives.
+- `Iterator` impls in `src/walk.rs` return `impl Iterator<Item = …>` (idiomatic for crate API).
+- `Display` placement is correct — user-facing in `Cli::format`, `Debug` everywhere else.
+
+---
+
+### Remediation Bundles
+
+| ID | Title                                 | Findings   | Files | Effort | Risk |
+|----|---------------------------------------|------------|-------|--------|------|
+| B1 | Replace clones with borrows in parser | I1, I2     | 2     | M      | Safe |
+| B2 | Idiomatic error propagation with `?`  | I3, I5, I9 | 3     | M      | Safe |
+| B3 | Iterator chains over manual loops     | I4, I6     | 1     | S      | Safe |
+```
+
+</details>
+
+> **Apply which bundles?** (e.g., "apply all", "apply B1 only", "skip — keep the report")
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/refactor/README.md
+++ b/skills/refactor/README.md
@@ -30,6 +30,53 @@ The key innovation is **cross-cutting synthesis**: changes that improve multiple
 /refactor "the database layer"           # Natural language scope description
 ```
 
+## Example
+
+Refactoring a TypeScript auth handler that mixes correctness, security, and performance concerns:
+
+```
+/refactor src/auth/handler.ts
+```
+
+<details>
+<summary>Sample plan</summary>
+
+```
+## Refactoring Plan: src/auth/handler.ts
+
+**Scope**: 1 file, 240 total lines | **Findings**: 7 (2 cross-cutting, 2 correctness/security, 1 performance, 2 structure)
+
+### Test Coverage
+Tests found — runner: `npm test -- src/auth/handler.test.ts`. 14 tests, all passing.
+
+---
+
+### Cross-Cutting Improvements (one change, multiple benefits)
+
+| ID   | File:Line                | Change                                      | Pillars | Confidence | Risk |
+|------|--------------------------|---------------------------------------------|---------|------------|------|
+| [R1] | `src/auth/handler.ts:42` | Replace inline crypto with `subtle.digest`  | [C+S]   | High       | Safe |
+| [R2] | `src/auth/handler.ts:88` | Memoize `decodeToken` per request           | [P+S]   | High       | Safe |
+
+---
+
+### Correctness & Security
+
+**[R3]** `src/auth/handler.ts:115` — Constant-time comparison missing on session-id check
+The `===` comparison is variable-time; switch to `crypto.timingSafeEqual` to close the timing-oracle gap.
+
+---
+
+### Strengths
+
+- Rate-limit middleware is correctly applied to `/login` and `/refresh` only.
+- Error responses do not leak internal detail to clients.
+```
+
+</details>
+
+> **Ready to apply these changes?** (e.g., "apply all", "apply R1 and R2", "apply all safe changes")
+
 ## Configuration
 
 | Setting | Value |

--- a/skills/test-gen/README.md
+++ b/skills/test-gen/README.md
@@ -27,6 +27,55 @@ Generates high-quality tests through deep code analysis and convention detection
 /test-gen src/api/users.py         # Works with any language
 ```
 
+## Example
+
+Generating tests for a date-parsing utility that has no test coverage:
+
+```
+/test-gen src/utils/parseDate.ts
+```
+
+<details>
+<summary>Sample plan + result</summary>
+
+```
+## Test Plan: src/utils/parseDate.ts
+
+**Target**: `parseDate` (5 branches) | **Tests**: 8 planned
+**Framework**: Vitest | **Pattern**: Co-located `*.test.ts` files
+**Test file**: `src/utils/parseDate.test.ts`
+
+### Critical Tests (must-have)
+
+**[T1]** `parseDate` — Parses ISO 8601 with timezone offset
+Type: unit
+Covers: happy path, the most-called shape in production usage
+
+**[T2]** `parseDate` — Returns `null` for empty input
+Type: edge case
+Covers: explicit early-return branch at line 12
+
+**[T3]** `parseDate` — Throws `InvalidDateError` for malformed input
+Type: error handling
+Covers: catch branch at line 28
+
+### Additional Coverage (nice-to-have)
+
+**[T4]–[T8]**: boundary years (1970, 2038), leap day, DST transitions, naive vs aware …
+
+### Already Covered (skipping)
+
+- `formatDate` — covered by `src/utils/formatDate.test.ts`
+
+[After approval, generation, and verification]
+
+> **All 8 tests passed.**
+```
+
+</details>
+
+> **Ready to generate these tests?** (e.g., "yes", "skip T5 and T7", "only critical")
+
 ## Configuration
 
 | Setting | Value |

--- a/templates/README.md
+++ b/templates/README.md
@@ -31,6 +31,29 @@ Or if the skill takes an argument:
 /skill-name <argument description>
 ```
 
+## Example
+
+A one-sentence scenario describing what the skill is being run against:
+
+```
+/skill-name <example argument>
+```
+
+<details>
+<summary>Sample output</summary>
+
+```
+A short, faithful transcript of what the skill prints when it finishes —
+ideally showing its distinctive surface (verdict banner, finding-ID format,
+report headings, action offer). Use real format strings, not invented ones.
+Keep it under ~25 lines so the README stays scannable; the <details> tag
+above already collapses it by default on GitHub.
+```
+
+</details>
+
+> **<Action question> ?** (e.g., "<example response>", "<another example>")
+
 ## Configuration
 
 | Setting | Value |


### PR DESCRIPTION
Closes #66

## Summary

- Insert `## Example` between `## Usage` and `## Configuration` in all 11 skill READMEs — each showing a 1-line scenario, the exact invocation, and a faithful abbreviated transcript wrapped in `<details><summary>Sample output</summary>…</details>`.
- Examples use each skill's real distinctive output surface — verdict banner (`NEEDS CHANGES ✗`), finding-ID prefix (`[C1]`, `[V1]`, `[H1]`, `[I1]`, `[D1]`, `[R1]`, `[T1]`), severity tables, scorecards, Remediation Bundle table, etc. — so the visual fingerprint teaches itself before installation.
- Root `README.md` skills table gains an `Example` column with deep-links to each skill's `#example` anchor.
- `templates/README.md` and `skills/create-skill/SKILL.md` R11 updated so new skills inherit the convention. `lint.sh` gains a soft `[warn]` if `## Example` is missing (non-blocking, modeled on the existing `## Safety` warn rule).
- `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [ ] `./lint.sh` → 252 passes, 0 warnings, 0 failures (each skill now reports `[pass] README has section: Example`)
- [ ] `./install.sh` → all 11 skills show `[skip] … already linked correctly` (symlinks intact)
- [ ] Visual: open `skills/code-review/README.md` on GitHub, confirm `<details>` collapse renders and the inner monospace transcript is legible
- [ ] Cross-link: click any row's `[view](…#example)` in the root `README.md` skills table and confirm it lands on the new `## Example` section
- [ ] Line-3 SKILL.md/README parity intact across all 11 skills (lint enforces this; clean pass confirms it)
