### PR TITLE
Spec compliance: takes-arg → argument-hint (Claude Code official frontmatter)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] `description` ends with a period and is verb-first
 - [ ] `description` in SKILL.md frontmatter matches README line 3 AND the root README table cell verbatim
 - [ ] `README.md` has all required sections (What It Does, Requirements, Usage, Configuration, Safety if applicable)
-- [ ] Configuration table has rows for `Model`, `Effort`, `Takes argument`, `Allowed tools`
+- [ ] Configuration table has rows for `Model`, `Effort`, `Argument hint`, `Allowed tools`
 - [ ] `Allowed tools` row matches the SKILL.md `allowed-tools` frontmatter exactly
 - [ ] Usage examples invoke `/<skill-name>` (not a stale name or another command)
 - [ ] If the skill uses `Agent` + Explore subagents: canonical IMPORTANT subagent block is present in the body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Migrated all skills from the repo-internal `takes-arg` field to the official Claude Code `argument-hint` field.** `takes-arg: true` was a documentation-only convention this repo invented; Claude Code never recognized it. Skills now declare `argument-hint: "[hint]"` (e.g., `code-review` → `[path | identifier | ref | range]`) which surfaces in `/<skill> <Tab>` autocomplete. The 7 affected skills: `code-review`, `create-skill`, `dep-check`, `diagnose`, `docstring-check`, `refactor`, `test-gen`.
+- **Documented the full official Claude Code skill frontmatter in `CLAUDE.md`.** Previously the optional-fields table listed 4 fields (`model`, `effort`, `disable-model-invocation`, `takes-arg`); it now lists every Claude Code-supported field (`argument-hint`, `arguments`, `when_to_use`, `paths`, `disable-model-invocation`, `user-invocable`, `context`, `agent`, `hooks`, `shell`) with the body-substitution table (`$ARGUMENTS`, `$N`, `$<name>`, `${CLAUDE_*}`) and dynamic context injection syntax (`` !`<command>` ``).
+- **`templates/SKILL.md` and `templates/README.md` updated to the new spec.** Template frontmatter now shows `argument-hint`, `arguments`, `when_to_use`, `paths`, `user-invocable`, `context`, `agent` as commented-out optional fields. Configuration table row renamed from `Takes argument` to `Argument hint`.
+- **All 11 skill READMEs renamed `Takes argument` row to `Argument hint`** with the matching hint string (or `No` for skills that take no argument).
+- **`create-skill`'s embedded R1–R13 reference updated to match the new spec.** R1 frontmatter table now documents `argument-hint`, `arguments`, `when_to_use`, `paths`, `user-invocable`, `context`, `agent`. R3 ARGUMENTS-line guidance, R9 argument-resolution cascade, and R11 README configuration table all use the new field name.
+
+### Added
+
+- **`lint.sh` enforces the new `argument-hint` contract.** The single-pass SKILL.md scanner now extracts the `argument-hint` value (passes when present) and the legacy `takes-arg` flag (warns when present so authors know to migrate). The README scanner now looks for the new `Argument hint` row and warns separately when it sees the legacy `Takes argument` row.
+
 ## [0.2.2] - 2026-05-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,14 +23,36 @@ Every `SKILL.md` must begin with YAML frontmatter between `---` delimiters.
 | `description` | One-line summary of what the skill does. Must end with a period and should be verb-first ("Scans...", "Audits...", "Performs..."). The same text must appear verbatim as the README first-line description and as the row in the root README skills table — `lint.sh` enforces all three matches. |
 | `allowed-tools` | Comma-separated list of tools the skill may use. The same list (in the same order) must appear in the README's `Configuration` table `Allowed tools` row — `lint.sh` enforces this parity. |
 
-**Optional fields:**
+**Optional fields** (this table tracks the official [Claude Code skill spec](https://code.claude.com/docs/en/skills#frontmatter-reference); fields not used by any skill in this repo are still listed for discoverability):
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `model` | (inherits) | Model to use: `opus`, `sonnet`, or `haiku` |
-| `effort` | (inherits) | Effort level: `min`, `low`, `medium`, `high`, `max` |
-| `disable-model-invocation` | `false` | Controls whether other models/skills may auto-invoke this skill via discovery/matching. Set `true` to keep the skill strictly user-triggered (the user must type `/<skill-name>` themselves). Does NOT prevent the skill from launching subagents via the `Agent` tool. Rarely needed — only `enhance` uses this in the current collection. |
-| `takes-arg` | `false` | Set `true` if the skill accepts an argument from the user |
+| `model` | (inherits) | Model to use: `opus`, `sonnet`, `haiku`, or `inherit` to keep the session model. Override applies for the rest of the current turn only. |
+| `effort` | (inherits) | Effort level: `low`, `medium`, `high`, `xhigh`, `max`. Available levels depend on the model. |
+| `argument-hint` | (none) | Hint shown during autocomplete (e.g., `[path \| identifier]`). The README's Configuration table `Argument hint` row must match this — `lint.sh` enforces parity. **Replaces the legacy repo-internal `takes-arg` field**, which was never recognized by Claude Code; `lint.sh` now warns on `takes-arg`. |
+| `arguments` | (none) | Named positional arguments for `$name` substitution in the body (e.g., `arguments: [target, mode]` enables `$target` and `$mode`). |
+| `when_to_use` | (none) | Additional trigger-phrase guidance for auto-invocation. Appended to `description` in the skill listing (counts toward the 1,536-character cap). |
+| `paths` | (none) | Glob patterns that auto-activate the skill when working with matching files (e.g., `["**/*.test.*"]`). |
+| `disable-model-invocation` | `false` | Set `true` to keep the skill strictly user-triggered (does NOT block subagents launched via the `Agent` tool). Rarely needed — only `enhance` uses this. |
+| `user-invocable` | `true` | Set `false` to hide the skill from the `/` menu (for background-knowledge skills only Claude should invoke). Differs from `disable-model-invocation` (which is the inverse). |
+| `context` | (none) | Set to `fork` to run the skill in a forked subagent context (skill body becomes the subagent's prompt). |
+| `agent` | `general-purpose` | When `context: fork` is set, picks the subagent type (`Explore`, `Plan`, `general-purpose`, or any custom agent in `.claude/agents/`). |
+| `hooks` | (none) | Skill-scoped hooks. See the [Claude Code hooks docs](https://code.claude.com/docs/en/hooks#hooks-in-skills-and-agents). |
+| `shell` | `bash` | Shell for `` !`command` `` blocks. `bash` (default) or `powershell` (requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`). |
+
+**Body substitutions and dynamic context injection** (Claude Code features the body can use):
+
+| Construct | Description |
+|-----------|-------------|
+| `$ARGUMENTS` | All user-supplied arguments as a single string. If absent from the body, Claude Code auto-appends `ARGUMENTS: <value>` to the rendered skill content. |
+| `$0`, `$1`, ... | Positional arguments by 0-based index (shell-style quoting). |
+| `$<name>` | Named argument declared in the `arguments:` frontmatter list. |
+| `${CLAUDE_SESSION_ID}` | Current session ID. |
+| `${CLAUDE_EFFORT}` | Active effort level (`low`/`medium`/`high`/`xhigh`/`max`). Lets the skill adapt its depth to the session's effort setting. |
+| `${CLAUDE_SKILL_DIR}` | Directory containing the skill's `SKILL.md`. Use to reference bundled scripts regardless of cwd. |
+| `` !`<command>` `` | **Dynamic context injection** — runs the shell command BEFORE Claude reads the skill, and the output replaces the placeholder. Use for deterministic, side-effect-free context-gathering. Multi-line variant: ` ```! ` fenced block. |
+
+**Migration note:** The legacy `takes-arg` field is repo-internal only — Claude Code's official spec uses `argument-hint` (autocomplete display) and/or `arguments` (named substitution). Skills should declare `argument-hint` instead; `lint.sh` warns if `takes-arg` is still present.
 
 ### SKILL.md Body
 
@@ -50,7 +72,7 @@ Every skill's `README.md` must contain these sections (in order):
 2. **What It Does** — Describe the workflow and phases. Use "delivered in N steps:" for step-numbered skills or "Runs a strategic N-phase analysis…" for phase-numbered skills.
 3. **Requirements** — Model access, dependencies, prerequisites
 4. **Usage** — How to invoke. Examples must use the skill's actual name (`/<skill-name>` — `lint.sh` enforces this).
-5. **Configuration** — Table of frontmatter settings with required rows: `Model`, `Effort`, `Takes argument`, `Allowed tools`. The `Allowed tools` row must list the same tools as the SKILL.md `allowed-tools` frontmatter (`lint.sh` enforces this parity).
+5. **Configuration** — Table of frontmatter settings with required rows: `Model`, `Effort`, `Argument hint`, `Allowed tools`. The `Allowed tools` row must list the same tools as the SKILL.md `allowed-tools` frontmatter (`lint.sh` enforces this parity). The `Argument hint` row should mirror the SKILL.md `argument-hint` frontmatter value, or say `No` for skills that take no argument.
 6. **Safety** (if applicable) — What the skill can and cannot modify
 
 See `skills/enhance/README.md` as the reference implementation.
@@ -88,5 +110,6 @@ Run `./lint.sh` to check all skills, or `./lint.sh <name>` for a specific skill.
 - README.md exists with required sections
 - README line 3 description matches SKILL.md `description` verbatim
 - Usage examples invoke the correct `/<skill-name>` (not stale names or unrelated commands)
-- Configuration table has `Takes argument` and `Allowed tools` rows
+- Configuration table has `Argument hint` and `Allowed tools` rows
 - `Allowed tools` row matches SKILL.md `allowed-tools` frontmatter (whitespace-normalized)
+- Warns if a SKILL.md still declares the legacy `takes-arg` field (use `argument-hint` instead)

--- a/lint.sh
+++ b/lint.sh
@@ -74,6 +74,7 @@ scan_skill_md() {
     local file="$1" line in_fm=0 past_fm=0 lineno=0
     FM_OPENED=0
     FM_NAME="" FM_DESC="" FM_TOOLS=""
+    FM_ARG_HINT="" FM_HAS_TAKES_ARG=0
     BODY_HAS_ENTER=0 BODY_HAS_EXIT=0 BODY_HAS_EXPLORE=0 BODY_HAS_IMPORTANT=0
     while IFS= read -r line || [[ -n "$line" ]]; do
         lineno=$((lineno + 1))
@@ -93,6 +94,8 @@ scan_skill_md() {
             if   [[ "$line" =~ ^name:[[:space:]]*(.*)$          ]]; then FM_NAME="${BASH_REMATCH[1]}"
             elif [[ "$line" =~ ^description:[[:space:]]*(.*)$   ]]; then FM_DESC="${BASH_REMATCH[1]}"
             elif [[ "$line" =~ ^allowed-tools:[[:space:]]*(.*)$ ]]; then FM_TOOLS="${BASH_REMATCH[1]}"
+            elif [[ "$line" =~ ^argument-hint:[[:space:]]*(.*)$ ]]; then FM_ARG_HINT="${BASH_REMATCH[1]}"
+            elif [[ "$line" =~ ^takes-arg:[[:space:]]*(true|false)[[:space:]]*$ ]]; then FM_HAS_TAKES_ARG=1
             fi
         else
             [[ "$line" == *"EnterPlanMode"* ]] && BODY_HAS_ENTER=1
@@ -125,7 +128,7 @@ scan_skill_md() {
 scan_readme_md() {
     local file="$1" line lineno=0 i
     HAS_USAGE=0 HAS_SAFETY=0 HAS_EXAMPLE=0
-    HAS_TAKES_ARG_ROW=0 HAS_ALLOWED_TOOLS_ROW=0
+    HAS_ARG_HINT_ROW=0 HAS_ALLOWED_TOOLS_ROW=0 HAS_LEGACY_TAKES_ARG_ROW=0
     README_DESC="" README_TOOLS_CELL=""
     README_REQUIRED_FOUND=()
     for i in "${!REQUIRED_README_SECTIONS[@]}"; do README_REQUIRED_FOUND[i]=0; done
@@ -144,8 +147,14 @@ scan_readme_md() {
             '## Safety'*)   HAS_SAFETY=1 ;;
             '## Example'*)  HAS_EXAMPLE=1 ;;
         esac
+        if [[ "$line" =~ ^\|[[:space:]]*Argument[[:space:]]+hint[[:space:]]*\| ]]; then
+            HAS_ARG_HINT_ROW=1
+        fi
+        # Detect legacy "Takes argument" row from the pre-argument-hint era so
+        # `lint.sh` can prompt the user to migrate the README alongside the
+        # SKILL.md frontmatter migration.
         if [[ "$line" =~ ^\|[[:space:]]*Takes[[:space:]]+argument[[:space:]]*\| ]]; then
-            HAS_TAKES_ARG_ROW=1
+            HAS_LEGACY_TAKES_ARG_ROW=1
         fi
         # Match a Configuration table row of the form:
         #   | Allowed tools | Bash, Read, Edit |
@@ -228,6 +237,16 @@ lint_skill() {
         fail "Missing required field: allowed-tools"
     else
         pass "Has 'allowed-tools' field"
+    fi
+
+    # Argument-hint hygiene: the legacy `takes-arg: true` field is repo-internal
+    # and never recognized by Claude Code. Warn (non-blocking) so existing forks
+    # keep linting clean while the migration progresses.
+    if (( FM_HAS_TAKES_ARG )); then
+        warn "frontmatter declares legacy 'takes-arg' (repo-internal, ignored by Claude Code) — replace with 'argument-hint: <hint>'"
+    fi
+    if [[ -n "$FM_ARG_HINT" ]]; then
+        pass "Has 'argument-hint' field: $FM_ARG_HINT"
     fi
 
     # Plan-mode discipline: when EnterPlanMode is declared, ExitPlanMode must
@@ -337,11 +356,15 @@ lint_skill() {
         fi
     fi
 
-    # Configuration table should include Takes argument and Allowed tools rows
-    if (( HAS_TAKES_ARG_ROW )); then
-        pass "Configuration table has 'Takes argument' row"
+    # Configuration table should include Argument hint and Allowed tools rows.
+    # The legacy "Takes argument" row name predates the migration to the
+    # official `argument-hint` field; warn separately so users know to rename.
+    if (( HAS_ARG_HINT_ROW )); then
+        pass "Configuration table has 'Argument hint' row"
+    elif (( HAS_LEGACY_TAKES_ARG_ROW )); then
+        warn "Configuration table uses legacy 'Takes argument' row — rename to 'Argument hint'"
     else
-        warn "Configuration table missing 'Takes argument' row"
+        warn "Configuration table missing 'Argument hint' row"
     fi
     if (( HAS_ALLOWED_TOOLS_ROW )); then
         pass "Configuration table has 'Allowed tools' row"

--- a/skills/code-review/README.md
+++ b/skills/code-review/README.md
@@ -75,7 +75,7 @@ The refresh-token branch returns the *old* token to the client even after rotati
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | Yes |
+| Argument hint | `[path \| identifier \| ref \| range]` |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -4,7 +4,7 @@ description: Structured code review across correctness, security, performance, a
 allowed-tools: Read, Grep, Glob, Bash, Agent, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
-takes-arg: true
+argument-hint: "[path | identifier | ref | range]"
 ---
 
 Call `EnterPlanMode` immediately before doing anything else.

--- a/skills/create-skill/README.md
+++ b/skills/create-skill/README.md
@@ -73,7 +73,7 @@ Scaffolding a new "C# security audit" skill from scratch:
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | Yes (optional: description of the skill to create) |
+| Argument hint | `[skill description]` (optional: description of the skill to create) |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -4,7 +4,7 @@ description: Interactive skill generator that scaffolds new skills following all
 allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
-takes-arg: true
+argument-hint: "[skill description]"
 ---
 
 Call `EnterPlanMode` immediately before doing anything else.
@@ -48,8 +48,14 @@ Every `SKILL.md` must begin with YAML frontmatter between `---` delimiters.
 
 | Field | Default | When to use |
 |-------|---------|-------------|
-| `takes-arg` | `false` | Set `true` if the skill accepts a user argument |
+| `argument-hint` | (none) | Set when the skill accepts an argument. Value is the autocomplete display string (e.g., `[target]` or `[path \| identifier]`). The README's `Argument hint` row must mirror this. **Replaces the legacy repo-internal `takes-arg` field**, which Claude Code never recognized. |
+| `arguments` | (none) | Optional named positional arguments for `$name` substitution in the body. With `arguments: [target]`, the body can reference `$target` to inline the first argument. |
+| `when_to_use` | (none) | Additional trigger-phrase guidance for auto-invocation. Useful when `description` alone would mismatch user requests. |
+| `paths` | (none) | Glob patterns that auto-activate the skill when working with matching files (e.g., `["**/*.test.*"]` for a testing skill). |
 | `disable-model-invocation` | `false` | Controls whether other models/skills may auto-invoke this skill via discovery/matching. Set `true` to keep the skill strictly user-triggered (the user must type `/<skill-name>` themselves). This does NOT prevent the skill from launching subagents via the `Agent` tool. Rarely needed — only `enhance` uses this in the current collection, to avoid being matched as a generic "improve the project" trigger. |
+| `user-invocable` | `true` | Set `false` to hide the skill from the `/` menu (background-knowledge skills only Claude should invoke). The inverse of `disable-model-invocation`. |
+| `context` | (none) | Set to `fork` to run the skill in a forked subagent context. The skill body becomes the subagent's prompt. |
+| `agent` | `general-purpose` | When `context: fork` is set, picks the subagent type (`Explore`, `Plan`, `general-purpose`, or any custom agent in `.claude/agents/`). |
 
 ---
 
@@ -101,12 +107,12 @@ The body follows this order after the frontmatter:
 
 2. **Mission statement** — 1-3 sentences describing what the skill does and its approach.
 
-3. **ARGUMENTS line** (only if `takes-arg: true`):
+3. **ARGUMENTS line** (only if `argument-hint` is declared):
    ```
    **ARGUMENTS:** The user may provide an optional <description of what the argument can be>. If no argument is provided, <fallback behavior>.
    ```
 
-4. **IMPORTANT: Quoting** (only if `takes-arg: true`):
+4. **IMPORTANT: Quoting** (only if `argument-hint` is declared):
    ```
    **IMPORTANT:** Always quote the user-supplied argument in double quotes when passing it to shell commands.
    ```
@@ -267,7 +273,7 @@ After exiting plan mode, ask the user what to do. The question must be:
 
 ### R9: Argument Resolution Cascade
 
-Skills with `takes-arg: true` resolve the argument in a priority order. The standard cascade:
+Skills that accept an argument (declare `argument-hint`) resolve it in a priority order. The standard cascade:
 
 1. **File path** — `test -f "<arg>"`
 2. **Directory path** — `test -d "<arg>"`
@@ -319,7 +325,7 @@ Every skill's `README.md` must contain these sections **in this order**:
 3. **Requirements** — model access, dependencies, prerequisites
 4. **Usage** — how to invoke (e.g., `/<skill-name>` or `/<skill-name> <argument>`). Examples MUST use the skill's actual name in the slash command.
 5. **Example** — a 1-line scenario, the exact invocation, and a faithful abbreviated transcript wrapped in `<details><summary>Sample output</summary>…</details>`. Use the skill's real format strings (verdict banners, finding-ID prefix, report headings) so users can recognize the output before they install. Avoid `## Usage`-style slash-command lines that reference OTHER skills inside `## Usage` (the linter scans Usage for cross-skill references); `## Example` is exempt from that check by design. Keep the visible part under ~25 lines.
-6. **Configuration** — table of frontmatter settings. Required rows: `Model`, `Effort`, `Takes argument`, `Allowed tools`. The `Allowed tools` row must list the SAME tools as the SKILL.md `allowed-tools` frontmatter (including `EnterPlanMode`/`ExitPlanMode` if they're there).
+6. **Configuration** — table of frontmatter settings. Required rows: `Model`, `Effort`, `Argument hint`, `Allowed tools`. The `Allowed tools` row must list the SAME tools as the SKILL.md `allowed-tools` frontmatter (including `EnterPlanMode`/`ExitPlanMode` if they're there). The `Argument hint` row should mirror the SKILL.md `argument-hint` value, or say `No` for skills that take no argument.
 7. **Safety** — bullet points with bold labels describing what the skill can and cannot do
 
 The **Safety** section uses this pattern:

--- a/skills/dep-check/README.md
+++ b/skills/dep-check/README.md
@@ -89,7 +89,7 @@ Update command:
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | Yes (optional: file path, directory, or ecosystem name) |
+| Argument hint | `[manifest \| directory \| ecosystem]` (optional: file path, directory, or ecosystem name) |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/dep-check/SKILL.md
+++ b/skills/dep-check/SKILL.md
@@ -4,7 +4,7 @@ description: Scans all dependency declarations across ecosystems, checks for upd
 allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
-takes-arg: true
+argument-hint: "[manifest | directory | ecosystem]"
 ---
 
 Call `EnterPlanMode` immediately before doing anything else.

--- a/skills/diagnose/README.md
+++ b/skills/diagnose/README.md
@@ -79,7 +79,7 @@ to `return data?.users`, but the dashboard still calls `.map(...)` without guard
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | Yes (optional: error message, stack trace, file path, or description) |
+| Argument hint | `[error \| path \| identifier]` (optional: error message, stack trace, file path, or description) |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -4,7 +4,7 @@ description: Multi-agent root cause analysis that traces errors, correlates with
 allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
-takes-arg: true
+argument-hint: "[error | path | identifier]"
 ---
 
 Call `EnterPlanMode` immediately before doing anything else.

--- a/skills/docstring-check/README.md
+++ b/skills/docstring-check/README.md
@@ -91,7 +91,7 @@ Linter available — will re-run `ruff check --select D src/users.py` after fixe
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | Yes (optional: file path, directory, symbol name, branch, commit range, or description) |
+| Argument hint | `[path \| symbol \| branch \| range]` (optional: file path, directory, symbol name, branch, commit range, or description) |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/docstring-check/SKILL.md
+++ b/skills/docstring-check/SKILL.md
@@ -4,7 +4,7 @@ description: Scans a codebase for missing, outdated, drifted, or inconsistent do
 allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
-takes-arg: true
+argument-hint: "[path | symbol | branch | range]"
 ---
 
 Call `EnterPlanMode` immediately before doing anything else.

--- a/skills/enhance/README.md
+++ b/skills/enhance/README.md
@@ -82,7 +82,7 @@ the substrate for a future `--metrics` exporter or a `replay` subcommand.
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | No |
+| Argument hint | No |
 | Disable model invocation | `true` |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, EnterPlanMode, ExitPlanMode, AskUserQuestion |
 

--- a/skills/github-audit/README.md
+++ b/skills/github-audit/README.md
@@ -73,7 +73,7 @@ Auditing a Rust library that just went public:
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | No |
+| Argument hint | No |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/github-ship/README.md
+++ b/skills/github-ship/README.md
@@ -96,7 +96,7 @@ Shipping a small fix from a clean working tree on `main`:
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | No |
+| Argument hint | No |
 | Allowed tools | Read, Grep, Glob, Bash, AskUserQuestion, EnterPlanMode, ExitPlanMode |
 
 No `Edit` or `Write` — all changes run through `git` or `gh`.

--- a/skills/idiom-check/README.md
+++ b/skills/idiom-check/README.md
@@ -89,7 +89,7 @@ Auditing a Rust crate where parser code clones strings unnecessarily:
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | No |
+| Argument hint | No |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/refactor/README.md
+++ b/skills/refactor/README.md
@@ -83,7 +83,7 @@ The `===` comparison is variable-time; switch to `crypto.timingSafeEqual` to clo
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | Yes (optional: file path, directory, function name, branch, commit range, or description) |
+| Argument hint | `[path \| identifier \| branch \| range]` (optional: file path, directory, function name, branch, commit range, or description) |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive code refactoring across correctness, security, perfor
 allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
-takes-arg: true
+argument-hint: "[path | identifier | branch | range]"
 ---
 
 Call `EnterPlanMode` immediately before doing anything else.

--- a/skills/test-gen/README.md
+++ b/skills/test-gen/README.md
@@ -82,7 +82,7 @@ Covers: catch branch at line 28
 |---------|-------|
 | Model | `opus` |
 | Effort | `max` |
-| Takes argument | Yes |
+| Argument hint | `[path \| identifier]` |
 | Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode |
 
 ## Safety

--- a/skills/test-gen/SKILL.md
+++ b/skills/test-gen/SKILL.md
@@ -4,7 +4,7 @@ description: Analyzes code to generate comprehensive tests covering happy paths,
 allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
-takes-arg: true
+argument-hint: "[path | identifier]"
 ---
 
 Call `EnterPlanMode` immediately before doing anything else.

--- a/templates/README.md
+++ b/templates/README.md
@@ -60,7 +60,7 @@ above already collapses it by default on GitHub.
 |---------|-------|
 | Model | `default` |
 | Effort | `default` |
-| Takes argument | No |
+| Argument hint | No |
 | Allowed tools | `Read, Grep, Glob, Bash, EnterPlanMode, ExitPlanMode` |
 
 The `Allowed tools` row must list the SAME tools as the SKILL.md `allowed-tools` frontmatter.

--- a/templates/SKILL.md
+++ b/templates/SKILL.md
@@ -2,10 +2,16 @@
 name: SKILL_NAME
 description: Verb-first one-line summary of what the skill does, ending with a period.
 allowed-tools: Read, Grep, Glob, Bash, EnterPlanMode, ExitPlanMode
-# model: opus                        # Optional: opus, sonnet, haiku
-# effort: max                        # Optional: min, low, medium, high, max
+# model: opus                        # Optional: opus, sonnet, haiku, inherit
+# effort: max                        # Optional: low, medium, high, xhigh, max
+# argument-hint: [target]            # Optional: autocomplete hint when the skill accepts an argument
+# arguments: [target]                # Optional: declare named positional args usable as $target in the body
+# when_to_use: Use when ...          # Optional: extra trigger-phrase guidance for auto-invocation
+# paths: ["src/**", "**/*.py"]       # Optional: glob patterns that auto-activate the skill
 # disable-model-invocation: true     # Optional: keep skill strictly user-triggered (does NOT block subagents)
-# takes-arg: true                    # Optional: accept an argument from the user
+# user-invocable: false              # Optional: hide from `/` menu (background-knowledge skills only)
+# context: fork                      # Optional: run in a forked subagent context
+# agent: Explore                     # Optional: subagent type when context: fork is set
 ---
 
 <!-- Skill prompt body. Replace this comment with content. -->
@@ -14,7 +20,9 @@ allowed-tools: Read, Grep, Glob, Bash, EnterPlanMode, ExitPlanMode
 <!-- 1. First line: `Call \`EnterPlanMode\` immediately   -->
 <!--    before doing anything else.`                       -->
 <!-- 2. 1-3 sentence mission statement                     -->
-<!-- 3. If takes-arg: ARGUMENTS line + quoting note        -->
+<!-- 3. If argument-hint declared: ARGUMENTS line +       -->
+<!--    quoting note (use $ARGUMENTS / $0 / $name as       -->
+<!--    needed)                                            -->
 <!-- 4. `---` separator                                    -->
 <!-- 5. Numbered steps (`## Step N: <Title>`) separated   -->
 <!--    by `---` rules                                     -->
@@ -27,6 +35,12 @@ allowed-tools: Read, Grep, Glob, Bash, EnterPlanMode, ExitPlanMode
 <!-- allowed-tools and fan out to 3 Explore agents if the  -->
 <!-- skill has THREE genuinely orthogonal analysis lenses. -->
 <!-- See `skills/create-skill/SKILL.md` R4 decision gate.  -->
+<!--                                                       -->
+<!-- Body substitutions: $ARGUMENTS, $0/$1/$N, $<name>,   -->
+<!-- ${CLAUDE_SESSION_ID}, ${CLAUDE_EFFORT},               -->
+<!-- ${CLAUDE_SKILL_DIR}. Use `` !`<command>` `` to run   -->
+<!-- a shell command BEFORE Claude reads the skill         -->
+<!-- (dynamic context injection).                          -->
 
 Call `EnterPlanMode` immediately before doing anything else.
 


### PR DESCRIPTION
## Summary

Migrates the repo from the home-grown `takes-arg: true` field to Claude Code's official `argument-hint` field. The `takes-arg` field was repo-internal; Claude Code never recognized it. The official spec uses `argument-hint` for autocomplete display and `arguments` for named-positional substitution.

This PR also adds the **full official Claude Code skill frontmatter reference** to `CLAUDE.md` (previously the optional-fields table listed only 4 fields; it now lists every supported field plus body substitutions and dynamic context injection syntax).

Generated by `/idiom-check`. Bundle B1 of 5 from the spec-alignment audit.

### What's in scope

**Frontmatter migration** (7 skills):
- `code-review` → `argument-hint: "[path | identifier | ref | range]"`
- `create-skill` → `argument-hint: "[skill description]"`
- `dep-check` → `argument-hint: "[manifest | directory | ecosystem]"`
- `diagnose` → `argument-hint: "[error | path | identifier]"`
- `docstring-check` → `argument-hint: "[path | symbol | branch | range]"`
- `refactor` → `argument-hint: "[path | identifier | branch | range]"`
- `test-gen` → `argument-hint: "[path | identifier]"`

**Documentation**:
- `CLAUDE.md` — full official frontmatter table (`argument-hint`, `arguments`, `when_to_use`, `paths`, `user-invocable`, `context`, `agent`, `hooks`, `shell`) + body substitutions (`$ARGUMENTS`, `$N`, `$<name>`, `${CLAUDE_*}`) + dynamic context injection (`` !`<command>` ``).
- `templates/SKILL.md` and `templates/README.md` updated to the new spec.
- `create-skill`'s embedded R1–R13 reference updated to match.
- `.github/PULL_REQUEST_TEMPLATE.md` checklist row updated.

**Linter** (`lint.sh`):
- Adds `argument-hint` scanner — passes when present.
- Adds legacy `takes-arg` warning so existing forks know to migrate.
- Renames `Takes argument` row check to `Argument hint`; warns separately on the legacy row.

**README parity** (all 11 skills):
- Configuration table row renamed `Takes argument` → `Argument hint`, with the matching hint string (or `No` for skills with no argument).

### Why this matters

Without `argument-hint`, `/skill-name <Tab>` shows no autocomplete hint to the user. Claude Code was silently ignoring `takes-arg` while the repo treated it as a real field. This brings the repo into compliance with the [official Claude Code skill spec](https://code.claude.com/docs/en/skills#frontmatter-reference) without changing skill behavior.

## Test plan

- [ ] `./lint.sh` passes with zero failures (currently 259/259 passing locally)
- [ ] Spot-check `/code-review <Tab>` shows `[path | identifier | ref | range]` autocomplete hint after install
- [ ] Verify a skill that takes no argument (e.g., `/idiom-check`) still parses cleanly
- [ ] Confirm CHANGELOG `[Unreleased]` entry is correct format