### PR TITLE
Wire cross-skill handoffs via Skill tool in 5 skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-skill handoffs via the `Skill` tool in 5 skills.** Previously only `github-audit` wired any handoffs. Now:
+  - `/code-review` → offers `/refactor` after fixes are applied (when structural smells go beyond the diff).
+  - `/diagnose` → offers `/test-gen` after a fix lands (write a regression test for the bug).
+  - `/refactor` → offers `/test-gen` after refactoring (refresh tests for renamed/restructured surfaces).
+  - `/idiom-check` → offers `/code-review` on each bundle PR (independent second pass before merge).
+  - `/dep-check` → offers `/test-gen` after major version bumps (cover the breaking-change surface).
+  Each handoff is gated on signal (only offered when warranted) and requires user approval before firing. `Skill` added to `allowed-tools` in both SKILL.md frontmatter and the README's `Allowed tools` row for each skill.
+- **`code-review` now declares `AskUserQuestion` in `allowed-tools`** alongside `Skill` (the action-offer step needs it for the structured handoff offer). Previously the body asked questions inline via prose only.
+- **`CLAUDE.md` Quality Standards section documents the Cross-skill handoffs pattern** — when to wire it (genuine workflow chaining), how it's gated (offer only when warranted), and the interaction model (user must approve the handoff before it fires).
+
 ## [0.2.2] - 2026-05-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ See `skills/enhance/README.md` as the reference implementation.
 - **Safety-conscious**: Skills that launch subagents should use read-only agent types (e.g., Explore) during analysis phases
 - **Plan-mode discipline**: If a skill enters plan mode, `ExitPlanMode` must be called BEFORE any Edit/Write operation — file modifications are blocked while plan mode is active
 - **Self-contained**: Each skill directory should contain everything needed; avoid cross-skill dependencies
+- **Cross-skill handoffs**: When a skill's primary action naturally chains into another installed skill (e.g., `/code-review` → `/refactor`, `/diagnose` → `/test-gen`, `/refactor` → `/test-gen`), declare `Skill` in `allowed-tools` and add a "Skill handoff" offer after the primary action completes. Offer the handoff only when there's genuine signal that the next skill adds value — never as a generic catch-all. The user must approve before the handoff fires.
 
 ## Validation
 

--- a/skills/code-review/README.md
+++ b/skills/code-review/README.md
@@ -76,7 +76,7 @@ The refresh-token branch returns the *old* token to the client even after rotati
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, EnterPlanMode, ExitPlanMode |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: Structured code review across correctness, security, performance, and conventions with prioritized findings and fix offers.
-allowed-tools: Read, Grep, Glob, Bash, Agent, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -239,5 +239,11 @@ If the user requests fixes:
 1. Address findings in severity order (Critical first, then Warnings)
 2. Show each change clearly
 3. After all fixes are applied, briefly note what was changed
+
+**Skill handoff.** If the review surfaced structural issues that go beyond the diff (e.g., a Critical finding that points at a long-standing architectural smell, or repeated patterns across the touched files), offer to hand off to `/refactor` via the `Skill` tool:
+
+> **Next:** Want me to run `/refactor` on the touched files for a deeper structural pass? It uses three orthogonal lenses (correctness/security, performance, structure) and produces an incremental plan.
+
+Only suggest the handoff when there's genuine signal that more work is warranted — don't surface it after a clean SHIP IT ✓ verdict or when only stylistic Suggestions remain.
 
 If the report verdict is **SHIP IT ✓** with no actionable findings, skip the fix offer and confirm the code looks good.

--- a/skills/dep-check/README.md
+++ b/skills/dep-check/README.md
@@ -90,7 +90,7 @@ Update command:
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: file path, directory, or ecosystem name) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, Skill, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/dep-check/SKILL.md
+++ b/skills/dep-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dep-check
 description: Scans all dependency declarations across ecosystems, checks for updates and vulnerabilities, and produces a prioritized update plan with testing recommendations.
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, TaskCreate, TaskUpdate, Skill, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -434,6 +434,12 @@ If the user requests updates, apply them by **editing the manifest files in plac
    > **Applied Group 1**: Updated 3 packages in `package.json`. Run `<install command>` then `<test command>` to verify.
 5. Do **not** run install commands (`npm install`, `pip install`, `cargo update`, `bundle install`, etc.) or test commands automatically. Once you've finished editing manifests, tell the user what to run. Always quote `<package>` and `<version>` arguments in the commands you suggest, since version constraints can contain shell metacharacters like `<`, `>`, and spaces:
    > I've updated the version declarations. Run `npm install` (or `cargo update -p "<package>"`, `bundle update "<gem>"`, `composer update "<package>"`, etc. — quote the package/version) to refresh lockfiles and install the new versions, then `<test command>` to verify.
+
+**Skill handoff.** Major version bumps can change behavior even when the API still type-checks. After applying any update group that contains a major bump, offer to hand off to `/test-gen` so the affected modules get fresh coverage before the user runs the test suite:
+
+> **Next:** Group <N> contains a major version bump (`<package> <old> → <new>`). Want me to hand off to `/test-gen` for the modules that consume `<package>` to add coverage around the breaking-change surface?
+
+Use the `Skill` tool to invoke `/test-gen` if the user agrees. Skip the handoff when only patch/minor updates were applied (low risk of behavior change) or when the project already has dense coverage of the affected modules.
 
 If the report shows zero updates and zero vulnerabilities, skip the update offer:
 > All dependencies are up to date and no known vulnerabilities were found.

--- a/skills/diagnose/README.md
+++ b/skills/diagnose/README.md
@@ -80,7 +80,7 @@ to `return data?.users`, but the dashboard still calls `.map(...)` without guard
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: error message, stack trace, file path, or description) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: diagnose
 description: Multi-agent root cause analysis that traces errors, correlates with recent changes, and identifies fixes with ranked hypotheses.
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebSearch, WebFetch, Edit, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -283,5 +283,11 @@ If the user requests a fix:
 3. If tests exist for the affected code, suggest running them:
    > Run `<test command>` to verify the fix resolves the issue.
 4. If the user reports the fix for H1 didn't work, suggest trying H2
+
+**Skill handoff.** After a fix is applied successfully, offer to write a regression test so the bug can't return:
+
+> **Next:** Want me to hand off to `/test-gen` for `<file>` to write a regression test that pins the bug shut? Useful when the affected code wasn't covered before.
+
+Use the `Skill` tool to invoke `/test-gen` if the user agrees. Skip the offer when the fix is purely configuration/environmental (no code path to regression-test) or when the user already runs `/test-gen` regularly.
 
 If no hypothesis has a code fix (e.g., environmental issue), provide the exact steps the user should take to resolve it.

--- a/skills/idiom-check/README.md
+++ b/skills/idiom-check/README.md
@@ -90,7 +90,7 @@ Auditing a Rust crate where parser code clones strings unnecessarily:
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | No |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, Skill, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/idiom-check/SKILL.md
+++ b/skills/idiom-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: idiom-check
 description: Audits a codebase through a programming-language-specific idiom lens, produces a prioritized report, and offers remediation in PR-sized bundles.
-allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, Skill, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 ---
@@ -372,3 +372,9 @@ default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@
 > - **[B3]** <B3 title> → <pr_url>
 >
 > Note: when merging these PRs, avoid `gh pr merge --delete-branch` if you stack any of them on top of each other — it closes dependent PRs.
+
+**Skill handoff.** After the PRs are open, offer to do an independent second pass via `/code-review` on each bundle's diff:
+
+> **Next:** Want me to hand off to `/code-review` for one or more of these PRs? Useful as a second pair of eyes before you merge — `/code-review` covers correctness, security, and conventions through a different lens than the idiom audit did.
+
+Use the `Skill` tool to invoke `/code-review` (with the PR's branch as the argument) if the user agrees. Skip the offer when the bundles were trivially small (single-file Low-severity polish) or when the user wants to merge immediately.

--- a/skills/refactor/README.md
+++ b/skills/refactor/README.md
@@ -84,7 +84,7 @@ The `===` comparison is variable-time; switch to `crypto.timingSafeEqual` to clo
 | Model | `opus` |
 | Effort | `max` |
 | Takes argument | Yes (optional: file path, directory, function name, branch, commit range, or description) |
-| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode |
+| Allowed tools | Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, Skill, EnterPlanMode, ExitPlanMode |
 
 ## Safety
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refactor
 description: Comprehensive code refactoring across correctness, security, performance, and maintainability with behavior-preserving, incremental changes.
-allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Grep, Glob, Bash, Agent, Edit, Write, AskUserQuestion, TaskCreate, TaskUpdate, Skill, EnterPlanMode, ExitPlanMode
 model: opus
 effort: max
 takes-arg: true
@@ -366,6 +366,12 @@ If the repository has uncommitted changes outside the refactoring scope, warn th
    >
    > Run `git diff` to review the changes before committing.
 
+   **Skill handoff.** After a successful refactor, offer to refresh tests for the touched modules — particularly when the refactoring renamed or restructured public surfaces:
+
+   > **Next:** Want me to hand off to `/test-gen` for the modified files to refresh test coverage and pick up any new branches the refactor introduced?
+
+   Use the `Skill` tool to invoke `/test-gen` if the user agrees. Skip the offer when the refactor was purely internal (e.g., a constant rename inside one function) and existing tests already exercise the surface.
+
 7. **If tests fail**, report which tests failed and diagnose the likely cause:
    > **<P> tests passed, <F> failed.** The failure appears related to [R4] (<brief diagnosis>).
    >
@@ -376,5 +382,9 @@ If the repository has uncommitted changes outside the refactoring scope, warn th
 
 8. **If no test runner is available:**
    > **All changes applied.** No test runner detected — review changes manually with `git diff` before committing.
-   >
-   > Consider running `/test-gen` to create tests for the refactored code.
+
+   **Skill handoff.** Offer to bootstrap a test infrastructure via `/test-gen` (which detects no-framework repos and proposes setup):
+
+   > **Next:** No test framework detected. Want me to hand off to `/test-gen` to scaffold one and write tests for the refactored modules?
+
+   Use the `Skill` tool to invoke `/test-gen` if the user agrees.


### PR DESCRIPTION
## Summary

Wires the `Skill` tool into 5 skills with natural follow-up workflows, so the action-offer step can launch the next skill instead of merely suggesting it as prose. Bundle B4 of 5; purely additive.

Previously only `/github-audit` used the `Skill` tool, despite multiple obvious handoff edges across the collection.

### Handoffs added

| From | To | When |
|------|-----|------|
| `/code-review` | `/refactor` | After fixes are applied, when structural smells go beyond the diff |
| `/diagnose` | `/test-gen` | After a fix lands — write a regression test for the bug |
| `/refactor` | `/test-gen` | After refactoring — refresh tests for renamed/restructured surfaces |
| `/idiom-check` | `/code-review` | After bundle PRs are open — independent second pass before merge |
| `/dep-check` | `/test-gen` | After major version bumps — cover the breaking-change surface |

Each handoff is **gated on signal** (only offered when warranted, never as a generic catch-all) and requires **user approval** before firing.

### Other changes

- `code-review` now declares `AskUserQuestion` in `allowed-tools` (needed for the new structured handoff offer).
- `CLAUDE.md` Quality Standards section documents the cross-skill handoff pattern: when to wire, how it's gated, and the interaction model (user must approve before the handoff fires).

## Test plan

- [x] `./lint.sh` passes (252/252)
- [ ] Verify each handoff prompt reads naturally inline with the existing action offer
- [ ] Confirm `Skill` tool appears in each skill's README Configuration `Allowed tools` row
- [ ] Spot-check that handoffs are gated (not surfaced after a clean SHIP IT, after patch-only `/dep-check`, etc.)