### PR TITLE
Pre-render deterministic context via Claude Code dynamic context injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Dynamic context injection (`` !`<command>` ``) in 4 skills.** Each skill now pre-renders its deterministic, side-effect-free context-gathering at the top of the body, so the data arrives in Claude's context before the skill body is read — saving a Bash round-trip and a chunk of tokens per invocation.
+  - `/github-ship` pre-renders: in-git-repo, github-remote, gh-authed, current branch, default branch, working-tree state, existing PR for current branch.
+  - `/code-review` pre-renders (auto-detect path only): current branch, default branch, staged files, unstaged files, branch-ahead-of-upstream commits.
+  - `/dep-check` pre-renders (no-arg path only): root-level manifest inventory, C# project files, GitHub Actions workflows, Dockerfiles, tooling pins, renovate/dependabot config presence.
+  - `/github-audit` pre-renders: repo slug (`owner/name`), default branch, license SPDX ID, topics, workflow file list. The slug + default branch are then substituted into the Phase 1 `gh api repos/<slug>/...` paths instead of being re-resolved.
+- **`CLAUDE.md` Quality Standards now documents the dynamic-context-injection idiom.** Specifies when to use it (deterministic, side-effect-free, idempotent commands; no `git push`/`gh pr create`/`npm install`) and when to keep commands in the body (anything that depends on the user's argument or runtime decisions).
+
 ## [0.2.2] - 2026-05-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ See `skills/enhance/README.md` as the reference implementation.
 - **Safety-conscious**: Skills that launch subagents should use read-only agent types (e.g., Explore) during analysis phases
 - **Plan-mode discipline**: If a skill enters plan mode, `ExitPlanMode` must be called BEFORE any Edit/Write operation — file modifications are blocked while plan mode is active
 - **Self-contained**: Each skill directory should contain everything needed; avoid cross-skill dependencies
+- **Dynamic context injection where deterministic**: When a skill's first step gathers context that does not depend on the user's argument (e.g., `git rev-parse --abbrev-ref HEAD`, `gh repo view --json ...`, `ls package.json Cargo.toml ...`), pre-render that context in the skill body using `` !`<command>` `` (or fenced ` ```! ` for multi-line). The harness runs the command BEFORE Claude reads the skill content, replacing the placeholder with the output — so Claude sees the pre-rendered values immediately and skips the redundant Bash round-trip. Use only for **fast, side-effect-free, idempotent** commands (no `git push`, no `gh pr create`, no `npm install`). For commands that depend on the user's argument or runtime decisions, keep them in the body so Claude can run them conditionally.
 
 ## Validation
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -15,6 +15,18 @@ You are performing a comprehensive, structured code review. Analyze code changes
 
 **IMPORTANT:** Always quote the user-supplied argument in double quotes when passing it to shell commands.
 
+## Pre-rendered context
+
+These values are computed by the harness before this skill runs (Claude Code dynamic context injection), so Step 1's auto-detect path has the working state in hand without spending a Bash round-trip on commands whose output is the same regardless of the argument:
+
+- **Current branch:** !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "(not a git repo)"`
+- **Default branch:** !`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || git rev-parse --verify main >/dev/null 2>&1 && echo main || git rev-parse --verify master >/dev/null 2>&1 && echo master || echo "(unknown)"`
+- **Staged files:** !`git diff --cached --name-only --diff-filter=ACMR 2>/dev/null | head -20 || echo "(none)"`
+- **Unstaged files:** !`git diff --name-only --diff-filter=ACMR 2>/dev/null | head -20 || echo "(none)"`
+- **Branch ahead of upstream:** !`git log --oneline @{u}.. 2>/dev/null | head -10 || echo "(no upstream or no ahead-commits)"`
+
+If an argument was provided, prefer that argument over the pre-rendered auto-detect data. The pre-rendered context is an optimization for the no-argument path.
+
 ---
 
 ## Step 1: Determine Review Scope

--- a/skills/dep-check/SKILL.md
+++ b/skills/dep-check/SKILL.md
@@ -15,6 +15,19 @@ You are performing a comprehensive dependency audit across all ecosystems presen
 
 **IMPORTANT:** Always quote the user-supplied argument in double quotes when passing it to shell commands.
 
+## Pre-rendered context
+
+The harness pre-renders manifest discovery (Claude Code dynamic context injection), so Step 1 starts with the ecosystem inventory already in hand. This is fast deterministic shell — no point spending a Bash round-trip on it.
+
+- **Root-level manifests present:** !`ls -1 package.json Cargo.toml pyproject.toml setup.py setup.cfg requirements.txt Pipfile go.mod Gemfile pom.xml build.gradle build.gradle.kts composer.json Package.swift 2>/dev/null || echo "(none at root)"`
+- **C# project files (depth ≤3):** !`find . -maxdepth 3 -type f -name '*.csproj' 2>/dev/null | head -5 || echo "(none)"`
+- **GitHub Actions workflows:** !`ls -1 .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null | head -10 || echo "(none)"`
+- **Dockerfile(s):** !`find . -maxdepth 3 -type f \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name 'docker-compose*.yml' -o -name 'compose*.yml' \) 2>/dev/null | head -10 || echo "(none)"`
+- **Tooling pins:** !`ls -1 .tool-versions .nvmrc .node-version .python-version .ruby-version .pre-commit-config.yaml 2>/dev/null || echo "(none)"`
+- **Renovate / dependabot config:** !`ls -1 .github/dependabot.yml .github/dependabot.yaml renovate.json renovate.json5 .renovaterc 2>/dev/null || echo "(none)"`
+
+If an argument was provided, scope the scan accordingly and treat the pre-rendered list as background context. If no argument was provided, use the pre-rendered list as the starting inventory and skip the redundant ecosystem-discovery shell calls in Step 1.
+
 ---
 
 ## Step 1: Discover Ecosystems and Manifest Files

--- a/skills/github-audit/SKILL.md
+++ b/skills/github-audit/SKILL.md
@@ -16,6 +16,18 @@ Execute each phase thoroughly before moving to the next. Use subagents for paral
 
 **IMPORTANT:** All subagents MUST be launched with `subagent_type: "Explore"` and `model: "opus"` (resolves to Claude Opus 4.7, the most capable model). The Explore agent is read-only by design (Edit and Write are denied at the agent level). This ensures no subagent can accidentally modify the project during analysis. The model override to Opus is required because Explore defaults to Haiku, which lacks the depth needed for this skill's thorough analysis. Never use general-purpose subagents in this skill.
 
+## Pre-rendered context
+
+The harness pre-renders the repository identity and a few scoping checks (Claude Code dynamic context injection) so Phase 1 doesn't re-run the same `gh` commands. Substitute the resolved `slug`/`default_branch` directly into the API paths in Phase 1's Agent 3.
+
+- **Repo slug (`owner/name`):** !`gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "(gh unavailable or not a github remote)"`
+- **Default branch:** !`gh repo view --json defaultBranchRef --jq .defaultBranchRef.name 2>/dev/null || echo "(unknown)"`
+- **License:** !`gh repo view --json licenseInfo --jq '.licenseInfo.spdxId // "(none detected)"' 2>/dev/null || echo "(gh unavailable)"`
+- **Topics:** !`gh repo view --json repositoryTopics --jq '[.repositoryTopics[].name] | join(",")' 2>/dev/null || echo "(none)"`
+- **Workflows present:** !`ls -1 .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null | head -10 || echo "(none)"`
+
+If `Repo slug` is `(gh unavailable...)`, stop in Phase 1 with an actionable error explaining that `gh` must be authenticated and the remote must be GitHub. Otherwise use the resolved slug in subsequent `gh api repos/<slug>/...` calls.
+
 ---
 
 ## Phase 1: Repository Scan

--- a/skills/github-ship/SKILL.md
+++ b/skills/github-ship/SKILL.md
@@ -15,32 +15,28 @@ You automate a GitHub issue + PR workflow. The user runs you with no arguments. 
 
 You never merge the PR yourself — that is always the user's action on GitHub.
 
+## Pre-rendered context
+
+These values are computed by the harness before this skill runs (via Claude Code's dynamic context injection), so Step 1 has the data it needs without an extra Bash round-trip:
+
+- **In a git repo?** !`git rev-parse --is-inside-work-tree 2>/dev/null || echo "no"`
+- **GitHub remote?** !`git remote get-url origin 2>/dev/null | grep -qE 'github\.com[:/]' && echo "yes" || echo "no"`
+- **gh authed?** !`gh auth status 2>&1 | grep -q "Logged in" && echo "yes" || echo "no"`
+- **Current branch:** !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "(unavailable)"`
+- **Default branch:** !`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || git rev-parse --verify main >/dev/null 2>&1 && echo main || git rev-parse --verify master >/dev/null 2>&1 && echo master || echo "(unknown)"`
+- **Working tree:** !`if [ -n "$(git status --porcelain 2>/dev/null)" ]; then echo "DIRTY ($(git status --porcelain 2>/dev/null | wc -l | tr -d ' ') files)"; else echo "clean"; fi`
+- **Existing PR for current branch:** !`gh pr list --head "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" --state all --json number,state,mergedAt,url --limit 1 --jq 'if length > 0 then .[0] else "(none)" end' 2>/dev/null || echo "(gh unavailable)"`
+
 ---
 
 ## Step 1: Pre-flight and Decide
 
-Check the environment. Stop with an actionable error on any failure.
+Read the **Pre-rendered context** above to make the routing decision without re-running the same commands. Stop with an actionable error on any failure (`In a git repo? = no`, `GitHub remote? = no`, `gh authed? = no`).
 
-```bash
-git rev-parse --is-inside-work-tree 2>/dev/null || echo "not_a_repo"
-git remote get-url origin 2>/dev/null | grep -qE 'github\.com[:/]' || echo "no_github_remote"
-gh auth status 2>&1 | grep -q "Logged in" || echo "gh_not_authenticated"
-```
+If the existing-PR row shows a `MERGED` state → go to **Step 3 (Cleanup)**.
+Otherwise → go to **Step 2 (Create)**. If a non-merged PR already exists, note that in the plan and offer to update it rather than create a new one.
 
-Resolve the default branch:
-
-```bash
-default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-[ -z "$default_branch" ] && git rev-parse --verify main >/dev/null 2>&1 && default_branch=main
-[ -z "$default_branch" ] && git rev-parse --verify master >/dev/null 2>&1 && default_branch=master
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-```
-
-Check whether a PR already exists for the current branch:
-
-```bash
-gh pr list --head "$current_branch" --state all --json number,state,mergedAt,url --limit 1 2>/dev/null
-```
+If you need fresher data than the pre-rendered values provide (e.g., the user just made changes after the skill loaded), re-run the relevant `git`/`gh` command via Bash.
 
 - If the PR state is `MERGED` → go to **Step 3 (Cleanup)**.
 - Otherwise → go to **Step 2 (Create)**. If a non-merged PR already exists, note that in the plan and offer to update it rather than create a new one.


### PR DESCRIPTION
## Summary

Adopts Claude Code's [dynamic context injection](https://code.claude.com/docs/en/skills#inject-dynamic-context) (`` !`<command>` ``) in 4 skills. Deterministic context-gathering now runs BEFORE Claude reads the skill body — so the data is already in the skill content when Claude starts thinking, saving a Bash round-trip and tokens per invocation.

Bundle B3 of 5; the most invasive of the 5 — please scrutinize the per-skill changes carefully.

### What changed per skill

**`/github-ship`** — Step 1 ("Pre-flight and Decide") was a fixed `git`/`gh` shell sequence. Pre-rendered: in-git-repo, github-remote, gh-authed, current branch, default branch, working-tree state, existing PR row. Step 1 now reads from these instead of shelling out.

**`/code-review`** — auto-detect path only (no-argument case): pre-rendered current branch, default branch, staged files, unstaged files, branch-ahead-of-upstream commits. The argument path is unchanged because the diff target depends on the argument.

**`/dep-check`** — no-argument path only: pre-rendered manifest inventory (root-level manifests, `*.csproj`, GitHub Actions workflows, Dockerfiles, tooling pins, renovate/dependabot config). Step 1 starts from this instead of re-running the same `ls`/`find` calls.

**`/github-audit`** — pre-rendered repo slug, default branch, license SPDX ID, topics, workflow file list. Phase 1's `gh api repos/<slug>/...` calls now substitute the resolved slug instead of re-resolving it.

### Documentation

- `CLAUDE.md` Quality Standards now documents the dynamic-context-injection idiom: when to use (deterministic, side-effect-free, idempotent — `git` read-only, `gh` read-only, `ls`, `find`), when to keep commands in the body (depends on argument or runtime decisions, or has side effects).

### What was deliberately kept in the body

- Anything that depends on `$ARGUMENTS` (e.g., `git diff "$arg"...HEAD`, `find "$arg" -type f`).
- Anything with side effects (`git push`, `gh pr create`, `npm install`).
- Anything that needs runtime branching (e.g., conditional execution based on detected state).

## Test plan

- [x] `./lint.sh` passes (252/252)
- [ ] Run `/github-ship` from a clean repo and verify the pre-rendered context is correctly inlined (check that branch, default-branch, working-tree-state values appear)
- [ ] Run `/code-review` with no argument and verify the pre-rendered branch state matches `git status` / `git diff --name-only`
- [ ] Run `/dep-check` with no argument and verify the pre-rendered manifest inventory matches the actual files
- [ ] Run `/github-audit` and verify the pre-rendered slug + default branch are then substituted into the Phase 1 `gh api` calls
- [ ] Verify each skill still works on a non-git repo / non-GitHub remote (the `|| echo "(unavailable)"` fallbacks)